### PR TITLE
Add .spi.yml for SPI-hosted API docs

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [Cadova]


### PR DESCRIPTION
Swift Package Index can generate DocC documentation and host it on the [Cadova package page](https://swiftpackageindex.com/tomasf/Cadova). Docs for that feature [here](https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/1.11.0/documentation/spimanifest/commonusecases).

This adds a .spi.yml file that enables documentation generation.

I considered adding a link to the docs to the readme  in this pr as well, but I think its better to wait for that until docs are built (they say it might take 24hrs or so) and we had a look at the results. Once that looks good I can follow up with a pr to adjust the readme.

It might be good to add links in the wiki where relevant, too. Maybe in the future it would be good to transition the wiki pages to DocC articles or sth as well, so that they are versioned and can more easily link to API docs, but I'm not very experienced with DocC so I can't promise I'd be the one to do that.