### PR TITLE
Add note about SPM doing silly naming things

### DIFF
--- a/Sources/Cadova/Cadova.docc/GettingStarted.md
+++ b/Sources/Cadova/Cadova.docc/GettingStarted.md
@@ -18,6 +18,8 @@ cd gizmo
 swift package init --type executable
 ```
 
+> Note: If SPM names your project file `gizmo.swift` and tries to manually add a `main` method, rename the file `main.swift` and delete the `main` method or you'll get a bunch of errors about concurrency. 
+
 ## 3. Add Cadova as a dependency
 
 Edit `Package.swift`:


### PR DESCRIPTION
## Change

I've updated docs to encourage people to check what SPM generates when running `swift package init` because otherwise you can get annoyingly stuck. 

## Reasoning

SPM seems to have changed its default behavior at some point so that for an executable, `main.swift` is not created. When I did this in an empty folder called `Playground`: 

```
swift package init --type executable
```

It logged out: 

```
Creating executable package: Playground
Creating Package.swift
Creating .gitignore
Creating Sources
Creating Sources/Playground/Playground.swift
Creating Tests/
Creating Tests/PlaygroundTests/
Creating Tests/PlaygroundTests/PlaygroundTests.swift
```

And created a `struct` annotated with `@main` in `Playground.swift`. If you try to add concurrency stuff to that, Xcode is like OH GOD WHAT ARE YOU DOING. If you wrap the concurrency stuff in a task within the main method, there's nothing to hold onto the task so it just goes out of scope without running, which is pretty annoying. The actual solution was to rename `Playground.swift` to `main.swift` and then just nuke the contents and put the sample code straight in there. 