### PR TITLE
Add CADOVA_LIVELINK_ONLY to skip the file write on a live link hit

### DIFF
--- a/Sources/Cadova/Concrete Layer/Build/Model/Model.swift
+++ b/Sources/Cadova/Concrete Layer/Build/Model/Model.swift
@@ -149,10 +149,31 @@ public struct Model: Sendable, ModelBuildable {
         let url = baseURL.appendingPathExtension(provider.fileExtension)
         let fileExisted = FileManager().fileExists(atPath: url.path(percentEncoded: false))
 
-        // Measured to overlap almost for free with writeOutput below (they touch the same cached
-        // EvaluationContext concurrently, which is safe — GeometryCache is dedup'd per node) —
-        // ~20% faster wall-clock on a substantial model, negligible difference on a small one.
-        async let liveLinkPush: Void = provider.pushToLiveLink(destination: url, context: context)
+        if LiveLinkSettings.isLiveLinkOnly {
+            // The push has to be awaited before deciding, so this path gives up the overlap
+            // below. That is the point: on a hit it skips generating the archive entirely,
+            // which costs far more than the overlap saved. On a miss it falls through and
+            // writes the file exactly as it always did.
+            if await provider.pushToLiveLink(destination: url, context: context) {
+                logger.debug("Skipped writing \(url.lastPathComponent): pushed over the live link")
+                return []
+            }
+        } else {
+            // Measured to overlap almost for free with writeOutput below (they touch the same cached
+            // EvaluationContext concurrently, which is safe — GeometryCache is dedup'd per node) —
+            // ~20% faster wall-clock on a substantial model, negligible difference on a small one.
+            async let liveLinkPush: Bool = provider.pushToLiveLink(destination: url, context: context)
+
+            do {
+                try await provider.writeOutput(to: url, context: context)
+                logger.info("Wrote model to \(url.path)")
+            } catch {
+                logger.error("Failed to save model file to \(url.path): \(error.descriptiveString)")
+            }
+
+            _ = await liveLinkPush
+            return fileExisted ? [] : [url]
+        }
 
         do {
             try await provider.writeOutput(to: url, context: context)
@@ -160,8 +181,6 @@ public struct Model: Sendable, ModelBuildable {
         } catch {
             logger.error("Failed to save model file to \(url.path): \(error.descriptiveString)")
         }
-
-        await liveLinkPush
 
         return fileExisted ? [] : [url]
     }

--- a/Sources/Cadova/Concrete Layer/Output Providers/3MF/LiveLinkSettings.swift
+++ b/Sources/Cadova/Concrete Layer/Output Providers/3MF/LiveLinkSettings.swift
@@ -8,7 +8,26 @@ internal enum LiveLinkSettings {
     nonisolated(unsafe) static var isDisabled = defaultIsDisabled()
 
     static func defaultIsDisabled(environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
-        switch environment["CADOVA_LIVELINK_DISABLED"]?.lowercased() {
+        boolean(environment["CADOVA_LIVELINK_DISABLED"])
+    }
+
+    /// Set `CADOVA_LIVELINK_ONLY=true` to skip writing the model file when the push
+    /// actually reached a listener that is watching that path. Intended for an interactive
+    /// edit loop, where the file is written on every save and never read: the viewer already
+    /// has the mesh over the socket before the archive is even generated.
+    ///
+    /// Deliberately narrow. If the live link is disabled, no host is listening, the host isn't
+    /// watching this path, or the push fails for any reason, the file is written exactly as
+    /// before — so the output can only be missing in the one case where something else
+    /// demonstrably already has the geometry.
+    nonisolated(unsafe) static var isLiveLinkOnly = defaultIsLiveLinkOnly()
+
+    static func defaultIsLiveLinkOnly(environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+        boolean(environment["CADOVA_LIVELINK_ONLY"])
+    }
+
+    private static func boolean(_ value: String?) -> Bool {
+        switch value?.lowercased() {
         case "1", "true", "yes", "on": true
         default: false
         }

--- a/Sources/Cadova/Concrete Layer/Output Providers/3MF/ThreeMFDataProvider.swift
+++ b/Sources/Cadova/Concrete Layer/Output Providers/3MF/ThreeMFDataProvider.swift
@@ -85,11 +85,11 @@ struct ThreeMFDataProvider: OutputDataProvider {
         lhs.localizedStandardCompare(rhs) == .orderedAscending
     }
 
-    func pushToLiveLink(destination url: URL, context: EvaluationContext) async {
+    func pushToLiveLink(destination url: URL, context: EvaluationContext) async -> Bool {
         #if canImport(CadovaLiveLinkClient)
         // Mirrors the socket-existence check `LiveLinkClient.push` makes internally before sending,
         // so we only log success when a listener is actually present to receive the push.
-        guard !LiveLinkSettings.isDisabled, FileManager.default.fileExists(atPath: LiveLinkEndpoint.socketPath) else { return }
+        guard !LiveLinkSettings.isDisabled, FileManager.default.fileExists(atPath: LiveLinkEndpoint.socketPath) else { return false }
 
         let path = url.path(percentEncoded: false)
         // Cheap, cached (read once per process — see LiveLinkClient.hostState) check for whether the
@@ -98,12 +98,12 @@ struct ThreeMFDataProvider: OutputDataProvider {
         // for every model in a project regardless of what's actually open in the viewer.
         guard LiveLinkClient.isInterested(inPath: path) else {
             logger.debug("Skipped live link push for \(url.lastPathComponent): host isn't watching this path")
-            return
+            return false
         }
 
         do {
             let parts = try await resolvedParts(context: context)
-            guard !parts.isEmpty else { return }
+            guard !parts.isEmpty else { return false }
             let identifiers = Self.fileIdentifiers(for: parts)
             let orderedParts = zip(identifiers, parts).sorted { Self.fileOrder($0.0, $1.0) }
             let message = LiveLinkMessage(
@@ -114,9 +114,13 @@ struct ThreeMFDataProvider: OutputDataProvider {
             )
             try await LiveLinkClient.push(message)
             logger.info("Pushed model \"\(url.lastPathComponent)\" to Cadova Viewer")
+            return true
         } catch {
             logger.debug("Skipped live link push for \(url.lastPathComponent): \(error)")
         }
+        return false
+        #else
+        return false
         #endif
     }
 

--- a/Sources/Cadova/Concrete Layer/Output Providers/OutputDataProvider.swift
+++ b/Sources/Cadova/Concrete Layer/Output Providers/OutputDataProvider.swift
@@ -8,7 +8,11 @@ protocol OutputDataProvider: Sendable {
     /// Viewer), bypassing the format-specific encoding `generateOutput` performs. Best-effort:
     /// implementations must never throw out of this method. The default does nothing, which is
     /// appropriate for formats with no 3D mesh worth short-circuiting a reload for.
-    func pushToLiveLink(destination url: URL, context: EvaluationContext) async
+    ///
+    /// Returns whether the data actually reached a listener, which is the only condition under
+    /// which a caller may skip writing the file.
+    @discardableResult
+    func pushToLiveLink(destination url: URL, context: EvaluationContext) async -> Bool
     var fileExtension: String { get }
 }
 
@@ -17,5 +21,5 @@ extension OutputDataProvider {
         try await generateOutput(context: context).write(to: url)
     }
 
-    func pushToLiveLink(destination url: URL, context: EvaluationContext) async {}
+    func pushToLiveLink(destination url: URL, context: EvaluationContext) async -> Bool { false }
 }


### PR DESCRIPTION
When a LiveLink host is already watching a model's destination path, the 3MF that Model.build() writes is never read: the viewer has had the mesh over the socket since before the archive was generated. Generating it anyway is the second largest cost in an interactive edit loop.

Measured on a 329,222 triangle model, release build, Apple M5 Max, 16 runs interleaved between the two conditions to cancel out machine load:

                    min      p25      median
  writes 3MF      1.099 s  1.424 s   2.028 s
  push only       0.706 s  0.982 s   1.137 s

That is 0.39-0.44 s per iteration, more than the 0.277 s the archive costs on its own, because skipping it also stops it competing with the push for cores. Compression level does not recover this: on a 1.21 M triangle model .fastest was slower than .standard (2.13 s against 1.82 s) for a file the same size to within 24 bytes. The cost is XML and archive assembly, not deflate.

The flag is opt-in and deliberately narrow. pushToLiveLink now reports whether the data reached a listener, and the write is skipped only on a true. If the live link is disabled, no host is listening, the host is not watching this path, or the push fails for any reason, the file is written exactly as before. Verified against all five cases.

With the flag unset, the concurrent push/write path is byte for byte the behaviour it had before.