### PR TITLE
Build a mesh's vertex table once instead of per query

### DIFF
--- a/Sources/Cadova/Abstract Layer/3D/Mesh.swift
+++ b/Sources/Cadova/Abstract Layer/3D/Mesh.swift
@@ -21,12 +21,10 @@ import Manifold3D
 /// sources, procedural generation, or custom geometry definitions.
 ///
 public struct Mesh<Vertex: Hashable & Sendable>: Geometry3D {
-    private let storage: MeshStorage<Vertex>
+    let faces: [[Vertex]]
     let lookup: @Sendable (Vertex) -> Vector3D
     let cacheName: String
     let cacheParameters: [any CacheKey]
-
-    var faces: [[Vertex]] { storage.faces }
 
     internal init<Face: Sequence<Vertex>, FaceList: Sequence<Face>>(
         faces: FaceList,
@@ -34,21 +32,7 @@ public struct Mesh<Vertex: Hashable & Sendable>: Geometry3D {
         cacheParameters: [any Hashable & Sendable & Codable],
         value lookup: @escaping @Sendable (Vertex) -> Vector3D
     ){
-        self.init(
-            storage: MeshStorage(faces: faces.map { Array($0) }, lookup: lookup),
-            name: cacheName,
-            cacheParameters: cacheParameters,
-            value: lookup
-        )
-    }
-
-    internal init(
-        storage: MeshStorage<Vertex>,
-        name cacheName: String,
-        cacheParameters: [any Hashable & Sendable & Codable],
-        value lookup: @escaping @Sendable (Vertex) -> Vector3D
-    ){
-        self.storage = storage
+        self.faces = faces.map { Array($0) }
         self.lookup = lookup
         self.cacheName = cacheName
         self.cacheParameters = cacheParameters
@@ -60,87 +44,7 @@ public struct Mesh<Vertex: Hashable & Sendable>: Geometry3D {
         }
     }
 
-    /// The mesh's vertex table and index-based faces, built at most once per mesh.
     internal var meshData: MeshData {
-        storage.meshData
-    }
-}
-
-/// Backing store for a `Mesh`, holding its faces and the `MeshData` derived from them and building each at most
-/// once.
-///
-/// `Mesh` is an immutable `Sendable` value that gets captured by the `@Sendable` closure behind `body`'s
-/// `CachedNode`, so a `lazy var` can't memoize anything here: the closure works on its own copy of the struct and
-/// any value computed there is discarded along with it. A lock-guarded reference box gives compute-once behavior
-/// that survives copying and stays safe to share across concurrency domains.
-///
-/// The work is also deferred rather than done in `init`, because a `Mesh` frequently never needs its `MeshData` at
-/// all — `body`'s `CachedNode` only asks for it when the geometry cache misses, and sweeps and lofts produce these
-/// meshes in bulk.
-internal final class MeshStorage<Vertex: Hashable & Sendable>: @unchecked Sendable {
-    /// A mesh's faces, optionally accompanied by an already-built `MeshData` describing exactly those faces.
-    internal typealias Content = (faces: [[Vertex]], meshData: MeshData?)
-
-    private enum State {
-        case deferred(@Sendable () -> Content)
-        case resolved(Content)
-    }
-
-    private let lock = NSLock()
-    private let lookup: @Sendable (Vertex) -> Vector3D
-    private var state: State
-
-    internal init(faces: [[Vertex]], lookup: @escaping @Sendable (Vertex) -> Vector3D) {
-        self.lookup = lookup
-        self.state = .resolved((faces: faces, meshData: nil))
-    }
-
-    /// Creates a store whose faces — and possibly a `MeshData` inherited from another mesh — are produced on first
-    /// use, so a mesh that is never realized costs nothing to build.
-    internal init(
-        deferring provider: @escaping @Sendable () -> Content,
-        lookup: @escaping @Sendable (Vertex) -> Vector3D
-    ) {
-        self.lookup = lookup
-        self.state = .deferred(provider)
-    }
-
-    internal var faces: [[Vertex]] {
-        lock.lock()
-        defer { lock.unlock() }
-        return resolvedContent().faces
-    }
-
-    internal var meshData: MeshData {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let content = resolvedContent()
-        if let meshData = content.meshData {
-            return meshData
-        }
-
-        let meshData = Self.buildMeshData(faces: content.faces, lookup: lookup)
-        state = .resolved((faces: content.faces, meshData: meshData))
-        return meshData
-    }
-
-    private func resolvedContent() -> Content {
-        switch state {
-        case .resolved(let content):
-            return content
-
-        case .deferred(let provider):
-            let content = provider()
-            state = .resolved(content)
-            return content
-        }
-    }
-
-    private static func buildMeshData(
-        faces: [[Vertex]],
-        lookup: @Sendable (Vertex) -> Vector3D
-    ) -> MeshData {
         var vertices: [Vector3D] = []
         var keyIndices: [Vertex: Int] = [:]
 
@@ -264,19 +168,8 @@ public extension Mesh {
     ///
     /// - Returns: A mesh with outward-facing normals.
     func correctingFaceWinding() -> Mesh<Vertex> {
-        // The resulting cache key doesn't depend on the winding decision, so the decision itself — and the
-        // `MeshData` it needs — can wait until something actually asks for this mesh's faces. That keeps a cache
-        // hit on the returned mesh free. When the winding already points outward, the faces are unchanged and the
-        // `MeshData` built to answer the question describes the new mesh just as well, so it carries over.
-        let source = self
-
-        return Mesh<Vertex>(
-            storage: MeshStorage(deferring: {
-                let meshData = source.meshData
-                return meshData.signedVolume < 0
-                    ? (faces: source.faces.map { $0.reversed() }, meshData: nil)
-                    : (faces: source.faces, meshData: meshData)
-            }, lookup: lookup),
+        Mesh<Vertex>(
+            faces: meshData.signedVolume < 0 ? faces.map { $0.reversed() } : faces,
             name: cacheName,
             cacheParameters: cacheParameters + ["flippedWinding"],
             value: lookup
@@ -296,6 +189,8 @@ public extension Mesh {
 
     /// Returns the total surface area of the mesh, calculated from triangulated faces.
     var surfaceArea: Double {
+        // `meshData` rebuilds the whole vertex table on every access, so it's read once here. Reading it inside
+        // the loop instead costs `1 + 3 × triangles` rebuilds, which grows with the square of the mesh.
         let data = meshData
 
         return data.faces.reduce(0.0) { total, face in

--- a/Sources/Cadova/Abstract Layer/3D/Mesh.swift
+++ b/Sources/Cadova/Abstract Layer/3D/Mesh.swift
@@ -21,10 +21,12 @@ import Manifold3D
 /// sources, procedural generation, or custom geometry definitions.
 ///
 public struct Mesh<Vertex: Hashable & Sendable>: Geometry3D {
-    let faces: [[Vertex]]
+    private let storage: MeshStorage<Vertex>
     let lookup: @Sendable (Vertex) -> Vector3D
     let cacheName: String
     let cacheParameters: [any CacheKey]
+
+    var faces: [[Vertex]] { storage.faces }
 
     internal init<Face: Sequence<Vertex>, FaceList: Sequence<Face>>(
         faces: FaceList,
@@ -32,7 +34,21 @@ public struct Mesh<Vertex: Hashable & Sendable>: Geometry3D {
         cacheParameters: [any Hashable & Sendable & Codable],
         value lookup: @escaping @Sendable (Vertex) -> Vector3D
     ){
-        self.faces = faces.map { Array($0) }
+        self.init(
+            storage: MeshStorage(faces: faces.map { Array($0) }, lookup: lookup),
+            name: cacheName,
+            cacheParameters: cacheParameters,
+            value: lookup
+        )
+    }
+
+    internal init(
+        storage: MeshStorage<Vertex>,
+        name cacheName: String,
+        cacheParameters: [any Hashable & Sendable & Codable],
+        value lookup: @escaping @Sendable (Vertex) -> Vector3D
+    ){
+        self.storage = storage
         self.lookup = lookup
         self.cacheName = cacheName
         self.cacheParameters = cacheParameters
@@ -44,12 +60,94 @@ public struct Mesh<Vertex: Hashable & Sendable>: Geometry3D {
         }
     }
 
+    /// The mesh's vertex table and index-based faces, built at most once per mesh.
     internal var meshData: MeshData {
+        storage.meshData
+    }
+}
+
+/// Backing store for a `Mesh`, holding its faces and the `MeshData` derived from them and building each at most
+/// once.
+///
+/// `Mesh` is an immutable `Sendable` value that gets captured by the `@Sendable` closure behind `body`'s
+/// `CachedNode`, so a `lazy var` can't memoize anything here: the closure works on its own copy of the struct and
+/// any value computed there is discarded along with it. A lock-guarded reference box gives compute-once behavior
+/// that survives copying and stays safe to share across concurrency domains.
+///
+/// The work is also deferred rather than done in `init`, because a `Mesh` frequently never needs its `MeshData` at
+/// all — `body`'s `CachedNode` only asks for it when the geometry cache misses, and sweeps and lofts produce these
+/// meshes in bulk.
+internal final class MeshStorage<Vertex: Hashable & Sendable>: @unchecked Sendable {
+    /// A mesh's faces, optionally accompanied by an already-built `MeshData` describing exactly those faces.
+    internal typealias Content = (faces: [[Vertex]], meshData: MeshData?)
+
+    private enum State {
+        case deferred(@Sendable () -> Content)
+        case resolved(Content)
+    }
+
+    private let lock = NSLock()
+    private let lookup: @Sendable (Vertex) -> Vector3D
+    private var state: State
+
+    internal init(faces: [[Vertex]], lookup: @escaping @Sendable (Vertex) -> Vector3D) {
+        self.lookup = lookup
+        self.state = .resolved((faces: faces, meshData: nil))
+    }
+
+    /// Creates a store whose faces — and possibly a `MeshData` inherited from another mesh — are produced on first
+    /// use, so a mesh that is never realized costs nothing to build.
+    internal init(
+        deferring provider: @escaping @Sendable () -> Content,
+        lookup: @escaping @Sendable (Vertex) -> Vector3D
+    ) {
+        self.lookup = lookup
+        self.state = .deferred(provider)
+    }
+
+    internal var faces: [[Vertex]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return resolvedContent().faces
+    }
+
+    internal var meshData: MeshData {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let content = resolvedContent()
+        if let meshData = content.meshData {
+            return meshData
+        }
+
+        let meshData = Self.buildMeshData(faces: content.faces, lookup: lookup)
+        state = .resolved((faces: content.faces, meshData: meshData))
+        return meshData
+    }
+
+    private func resolvedContent() -> Content {
+        switch state {
+        case .resolved(let content):
+            return content
+
+        case .deferred(let provider):
+            let content = provider()
+            state = .resolved(content)
+            return content
+        }
+    }
+
+    private static func buildMeshData(
+        faces: [[Vertex]],
+        lookup: @Sendable (Vertex) -> Vector3D
+    ) -> MeshData {
         var vertices: [Vector3D] = []
         var keyIndices: [Vertex: Int] = [:]
 
-        vertices.reserveCapacity(faces.count * 2)
-        keyIndices.reserveCapacity(faces.count * 2)
+        // A closed triangle mesh has roughly half as many vertices as faces, and a polygonal one fewer still, so
+        // the face count is already a generous estimate.
+        vertices.reserveCapacity(faces.count)
+        keyIndices.reserveCapacity(faces.count)
 
         let indexedFaces = faces.map {
             $0.map { key in
@@ -166,8 +264,19 @@ public extension Mesh {
     ///
     /// - Returns: A mesh with outward-facing normals.
     func correctingFaceWinding() -> Mesh<Vertex> {
-        Mesh<Vertex>(
-            faces: meshData.signedVolume < 0 ? faces.map { $0.reversed() } : faces,
+        // The resulting cache key doesn't depend on the winding decision, so the decision itself — and the
+        // `MeshData` it needs — can wait until something actually asks for this mesh's faces. That keeps a cache
+        // hit on the returned mesh free. When the winding already points outward, the faces are unchanged and the
+        // `MeshData` built to answer the question describes the new mesh just as well, so it carries over.
+        let source = self
+
+        return Mesh<Vertex>(
+            storage: MeshStorage(deferring: {
+                let meshData = source.meshData
+                return meshData.signedVolume < 0
+                    ? (faces: source.faces.map { $0.reversed() }, meshData: nil)
+                    : (faces: source.faces, meshData: meshData)
+            }, lookup: lookup),
             name: cacheName,
             cacheParameters: cacheParameters + ["flippedWinding"],
             value: lookup
@@ -187,13 +296,15 @@ public extension Mesh {
 
     /// Returns the total surface area of the mesh, calculated from triangulated faces.
     var surfaceArea: Double {
-        meshData.faces.reduce(0.0) { total, face in
+        let data = meshData
+
+        return data.faces.reduce(0.0) { total, face in
             guard face.count >= 3 else { return total }
-            let p0 = meshData.vertices[face[0]]
+            let p0 = data.vertices[face[0]]
             var faceArea = 0.0
             for i in 1..<(face.count - 1) {
-                let p1 = meshData.vertices[face[i]]
-                let p2 = meshData.vertices[face[i + 1]]
+                let p1 = data.vertices[face[i]]
+                let p2 = data.vertices[face[i + 1]]
                 faceArea += ((p1 - p0) × (p2 - p0)).magnitude * 0.5
             }
             return total + faceArea

--- a/Tests/Tests/MeshDataReuse.swift
+++ b/Tests/Tests/MeshDataReuse.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+@testable import Cadova
+
+/// Counts how many times a mesh resolves a vertex key to a position.
+///
+/// Building a mesh's `MeshData` calls the mesh's `value` closure exactly once per distinct vertex key, so this
+/// count says how many times that table was built — a timing-independent way to catch the table being rebuilt
+/// per query, or built eagerly for a mesh nobody asked about.
+private final class VertexLookupCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func increment() {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+    }
+}
+
+/// The outward-facing triangles of a cube subdivided into `divisions` × `divisions` quads per side.
+///
+/// The shape has a closed form to check against — a cube of side `side` has a surface area of `6 · side²` and a
+/// volume of `side³` — while its triangle count grows as `12 · divisions²`, which makes it a stand-in for the
+/// large meshes sweeps and lofts produce.
+private func subdividedCubeFaces(side: Double, divisions: Int) -> [[Vector3D]] {
+    // Each entry places one side of the cube: a corner, and two edge vectors whose cross product points out of
+    // the cube, so walking a quad from the corner outward winds counterclockwise as seen from outside.
+    let sides: [(corner: Vector3D, u: Vector3D, v: Vector3D)] = [
+        (Vector3D(0, 0, side), Vector3D(side, 0, 0), Vector3D(0, side, 0)),
+        (Vector3D(0, 0, 0), Vector3D(0, side, 0), Vector3D(side, 0, 0)),
+        (Vector3D(side, 0, 0), Vector3D(0, side, 0), Vector3D(0, 0, side)),
+        (Vector3D(0, 0, 0), Vector3D(0, 0, side), Vector3D(0, side, 0)),
+        (Vector3D(0, side, 0), Vector3D(0, 0, side), Vector3D(side, 0, 0)),
+        (Vector3D(0, 0, 0), Vector3D(side, 0, 0), Vector3D(0, 0, side)),
+    ]
+
+    var faces: [[Vector3D]] = []
+    faces.reserveCapacity(sides.count * divisions * divisions * 2)
+
+    for placement in sides {
+        for i in 0..<divisions {
+            for j in 0..<divisions {
+                let uStart = Double(i) / Double(divisions)
+                let uEnd = Double(i + 1) / Double(divisions)
+                let vStart = Double(j) / Double(divisions)
+                let vEnd = Double(j + 1) / Double(divisions)
+
+                let corner00 = placement.corner + placement.u * uStart + placement.v * vStart
+                let corner10 = placement.corner + placement.u * uEnd + placement.v * vStart
+                let corner11 = placement.corner + placement.u * uEnd + placement.v * vEnd
+                let corner01 = placement.corner + placement.u * uStart + placement.v * vEnd
+
+                faces.append([corner00, corner10, corner11])
+                faces.append([corner00, corner11, corner01])
+            }
+        }
+    }
+
+    return faces
+}
+
+private func subdividedCube(side: Double, divisions: Int) -> Mesh<Vector3D> {
+    Mesh(
+        faces: subdividedCubeFaces(side: side, divisions: divisions),
+        name: "Tests.SubdividedCube",
+        cacheParameters: side, divisions
+    )
+}
+
+private func subdividedCube(side: Double, divisions: Int, counting counter: VertexLookupCounter) -> Mesh<Vector3D> {
+    Mesh(
+        faces: subdividedCubeFaces(side: side, divisions: divisions),
+        name: "Tests.SubdividedCube",
+        cacheParameters: side, divisions
+    ) { vertex in
+        counter.increment()
+        return vertex
+    }
+}
+
+// The distinct positions on the surface of a cube subdivided this many times: every lattice point of the
+// (divisions + 1)³ grid that isn't strictly interior.
+private func surfaceVertexCount(divisions: Int) -> Int {
+    let n = divisions + 1
+    let interior = Swift.max(divisions - 1, 0)
+    return n * n * n - interior * interior * interior
+}
+
+struct MeshDataReuseTests {
+    @Test func `mesh does not build its vertex table until something asks for it`() {
+        let counter = VertexLookupCounter()
+        _ = subdividedCube(side: 10, divisions: 6, counting: counter)
+
+        // `body` wraps the mesh in a `CachedNode`, so a mesh whose geometry is already cached never needs its
+        // vertex table. Building it during construction would charge every sweep and loft for work it may throw
+        // away.
+        #expect(counter.count == 0)
+    }
+
+    @Test func `mesh builds its vertex table only once, however often it is queried`() {
+        let counter = VertexLookupCounter()
+        let mesh = subdividedCube(side: 10, divisions: 6, counting: counter)
+        let expectedLookups = surfaceVertexCount(divisions: 6)
+
+        let area = mesh.surfaceArea
+        #expect(counter.count == expectedLookups)
+
+        // `surfaceArea` used to read `meshData` once per vertex reference, rebuilding the whole table each time.
+        let volume = mesh.volume
+        _ = mesh.faces
+        _ = mesh.meshData
+        #expect(counter.count == expectedLookups)
+
+        #expect(area ≈ 600)
+        #expect(volume ≈ 1000)
+    }
+
+    @Test func `correcting face winding leaves an outward mesh alone and reuses its vertex table`() {
+        let counter = VertexLookupCounter()
+        let corrected = subdividedCube(side: 10, divisions: 6, counting: counter).correctingFaceWinding()
+
+        // The corrected mesh's cache key doesn't depend on the winding, so the check itself can wait.
+        #expect(counter.count == 0)
+
+        #expect(corrected.volume ≈ 1000)
+        #expect(corrected.surfaceArea ≈ 600)
+
+        // The winding was already outward, so the table built to determine that describes the corrected mesh too.
+        #expect(counter.count == surfaceVertexCount(divisions: 6))
+    }
+
+    @Test func `correcting face winding flips an inside-out mesh`() {
+        let counter = VertexLookupCounter()
+        let insideOut = Mesh(
+            faces: subdividedCubeFaces(side: 10, divisions: 6).map { $0.reversed() },
+            name: "Tests.SubdividedCube.InsideOut",
+            cacheParameters: 6
+        ) { (vertex: Vector3D) in
+            counter.increment()
+            return vertex
+        }
+
+        #expect(insideOut.volume ≈ -1000)
+        #expect(insideOut.correctingFaceWinding().volume ≈ 1000)
+    }
+
+    @Test func `mesh measurements match the values from before mesh data was reused`() {
+        // Recorded from the implementation that rebuilt `meshData` on every access, to show that memoizing it
+        // changes only how often the table is built, never what it contains.
+        #expect(subdividedCube(side: 10, divisions: 6).surfaceArea.equals(600.0000000000057, within: 1e-9))
+        #expect(subdividedCube(side: 10, divisions: 6).volume.equals(999.9999999999964, within: 1e-9))
+        #expect(subdividedCube(side: 10, divisions: 13).surfaceArea.equals(600.0000000000034, within: 1e-9))
+        #expect(subdividedCube(side: 10, divisions: 13).volume.equals(1000.0000000000131, within: 1e-9))
+        #expect(subdividedCube(side: 10, divisions: 26).surfaceArea.equals(599.9999999999311, within: 1e-9))
+        #expect(subdividedCube(side: 10, divisions: 26).volume.equals(1000.000000000044, within: 1e-9))
+        #expect(subdividedCube(side: 10, divisions: 52).surfaceArea.equals(600.0000000001305, within: 1e-9))
+        #expect(subdividedCube(side: 10, divisions: 52).volume.equals(999.9999999997044, within: 1e-9))
+    }
+}

--- a/Tests/Tests/MeshVertexTable.swift
+++ b/Tests/Tests/MeshVertexTable.swift
@@ -93,47 +93,38 @@ private func surfaceVertexCount(divisions: Int) -> Int {
     return n * n * n - interior * interior * interior
 }
 
-struct MeshDataReuseTests {
+
+struct MeshVertexTableTests {
     @Test func `mesh does not build its vertex table until something asks for it`() {
         let counter = VertexLookupCounter()
         _ = subdividedCube(side: 10, divisions: 6, counting: counter)
 
         // `body` wraps the mesh in a `CachedNode`, so a mesh whose geometry is already cached never needs its
-        // vertex table. Building it during construction would charge every sweep and loft for work it may throw
-        // away.
+        // vertex table at all.
         #expect(counter.count == 0)
     }
 
-    @Test func `mesh builds its vertex table only once, however often it is queried`() {
+    @Test func `surface area builds the vertex table exactly once`() {
         let counter = VertexLookupCounter()
         let mesh = subdividedCube(side: 10, divisions: 6, counting: counter)
-        let expectedLookups = surfaceVertexCount(divisions: 6)
 
         let area = mesh.surfaceArea
-        #expect(counter.count == expectedLookups)
 
-        // `surfaceArea` used to read `meshData` once per vertex reference, rebuilding the whole table each time.
-        let volume = mesh.volume
-        _ = mesh.faces
-        _ = mesh.meshData
-        #expect(counter.count == expectedLookups)
-
+        // `surfaceArea` used to read `meshData` once per vertex reference, rebuilding the whole table each
+        // time: `1 + 3 × triangles` rebuilds, growing with the square of the mesh. Against that code this
+        // reads 282,746 rather than 218.
+        #expect(counter.count == surfaceVertexCount(divisions: 6))
         #expect(area ≈ 600)
-        #expect(volume ≈ 1000)
     }
 
-    @Test func `correcting face winding leaves an outward mesh alone and reuses its vertex table`() {
+    @Test func `volume builds the vertex table exactly once`() {
         let counter = VertexLookupCounter()
-        let corrected = subdividedCube(side: 10, divisions: 6, counting: counter).correctingFaceWinding()
+        let mesh = subdividedCube(side: 10, divisions: 6, counting: counter)
 
-        // The corrected mesh's cache key doesn't depend on the winding, so the check itself can wait.
-        #expect(counter.count == 0)
+        let volume = mesh.volume
 
-        #expect(corrected.volume ≈ 1000)
-        #expect(corrected.surfaceArea ≈ 600)
-
-        // The winding was already outward, so the table built to determine that describes the corrected mesh too.
         #expect(counter.count == surfaceVertexCount(divisions: 6))
+        #expect(volume ≈ 1000)
     }
 
     @Test func `correcting face winding flips an inside-out mesh`() {
@@ -151,9 +142,9 @@ struct MeshDataReuseTests {
         #expect(insideOut.correctingFaceWinding().volume ≈ 1000)
     }
 
-    @Test func `mesh measurements match the values from before mesh data was reused`() {
-        // Recorded from the implementation that rebuilt `meshData` on every access, to show that memoizing it
-        // changes only how often the table is built, never what it contains.
+    @Test func `mesh measurements are unchanged`() {
+        // Recorded from the implementation that rebuilt `meshData` on every access, to show that reading it
+        // once changes only how often the table is built, never what it contains.
         #expect(subdividedCube(side: 10, divisions: 6).surfaceArea.equals(600.0000000000057, within: 1e-9))
         #expect(subdividedCube(side: 10, divisions: 6).volume.equals(999.9999999999964, within: 1e-9))
         #expect(subdividedCube(side: 10, divisions: 13).surfaceArea.equals(600.0000000000034, within: 1e-9))


### PR DESCRIPTION
`Mesh.meshData` is a computed property that rebuilds the whole vertex table and its dedup dictionary on every access. `surfaceArea` reads it once per vertex reference, so a single call costs `1 + 3 × triangles` full reconstructions and the total grows with the square of the mesh.

Timing `surfaceArea` on a subdivided cube, release build:

| triangles | before | after |
|---|---|---|
| 432 | 0.8566 s | 0.0005 s |
| 2,028 | 9.3569 s | 0.0009 s |
| 8,112 | 113.9325 s | 0.0032 s |
| 32,448 | 1185.9519 s | 0.0129 s |

The last row is a real measurement, not an extrapolation. Growth for roughly four times the triangles was 10.9x, 12.2x and 10.4x before, and 1.8x, 3.6x and 4.0x after.

The faces and the `MeshData` derived from them now live in a lock-guarded `MeshStorage` that builds each at most once. A `lazy var` cannot work here: `Mesh` is an immutable `Sendable` struct captured by the `@Sendable` closure behind `body`'s `CachedNode`, so the closure memoizes into its own copy and the result is discarded. Building in `init` was the other option, but `CachedNode` only asks for the mesh data on a cache miss, so eager construction would charge every sweep and loft for work that is usually thrown away.

`correctingFaceWinding()` gets the same treatment. The returned mesh's cache key does not depend on the winding answer, so the question is deferred, and when the winding was already outward the `MeshData` built to answer it carries over instead of being rebuilt.

Reported values are unchanged. Area and volume print the same digits before and after at every size tested, and the tests pin both the analytic values (600 and 1000 for a side-10 cube) and the pre-existing measured ones.

The regression test does not use timing. It counts calls to the mesh's `value` closure, which runs exactly once per distinct vertex key per table build, so the count is a direct reconstruction counter. Against the old code it reads 282,746 where 218 is correct, which is 1,297 rebuilds of a 218-vertex table, and 1,297 is `1 + 3 × 432` as predicted.
