### PR TITLE
Fix copy counts in the duplication operations

### DIFF
--- a/Sources/Cadova/Abstract Layer/Operations/Duplication/RepeatAlong.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/Duplication/RepeatAlong.swift
@@ -25,9 +25,9 @@ extension Geometry {
     @GeometryBuilder<D>
     public func repeated(along axis: D.Axis, in range: Range<Double>, count: Int) -> D.Geometry {
         if count > 0 {
-            let step = (range.upperBound - range.lowerBound) / Double(count)
-            for value in stride(from: range.lowerBound, to: range.upperBound, by: step) {
-                translated(D.Vector(axis, value: value))
+            let span = range.upperBound - range.lowerBound
+            for i in 0..<count {
+                translated(D.Vector(axis, value: range.lowerBound + span * (Double(i) / Double(count))))
             }
         }
     }
@@ -43,9 +43,9 @@ extension Geometry {
     @GeometryBuilder<D>
     public func repeated(along axis: D.Axis, in range: ClosedRange<Double>, count: Int) -> D.Geometry {
         if count > 1 {
-            let step = (range.upperBound - range.lowerBound) / Double(count - 1)
-            for value in stride(from: range.lowerBound, through: range.upperBound, by: step) {
-                translated(D.Vector(axis, value: value))
+            let span = range.upperBound - range.lowerBound
+            for i in 0..<count {
+                translated(D.Vector(axis, value: range.lowerBound + span * (Double(i) / Double(count - 1))))
             }
         } else if count == 1 {
             translated(D.Vector(axis, value: range.lowerBound))
@@ -103,25 +103,54 @@ extension Geometry {
     ///
     public func repeated(along axis: D.Axis, in range: ClosedRange<Double>, minimumSpacing: Double, cyclically: Bool = false) -> D.Geometry {
         measuringBounds { _, bounds in
-            let boundsLength = bounds.size[axis]
-            let rangeLength = range.upperBound - range.lowerBound
+            let placement = automaticSpacingPlacement(
+                rangeLength: range.upperBound - range.lowerBound,
+                instanceLength: bounds.size[axis],
+                minimumSpacing: minimumSpacing,
+                cyclically: cyclically
+            )
 
-            if cyclically {
-                let count = Int(floor(rangeLength / (boundsLength + minimumSpacing)))
-                if count > 0 {
-                    let step = rangeLength / Double(count)
-                    self.repeated(along: axis, step: step, count: count)
-                        .translated(D.Vector(axis, value: range.lowerBound))
-                }
-            } else {
-                let availableLength = rangeLength - boundsLength
-                let count = Int(floor(availableLength / (boundsLength + minimumSpacing)))
-                if count > 0 {
-                    let step = availableLength / Double(count)
-                    self.repeated(along: axis, step: step, count: count + 1)
-                        .translated(D.Vector(axis, value: range.lowerBound))
-                }
+            if let placement {
+                self.repeated(along: axis, step: placement.step, count: placement.count)
+                    .translated(D.Vector(axis, value: range.lowerBound))
             }
         }
+    }
+}
+
+/// Works out how many instances fit in a range and how far apart to put them, or `nil` if not even one
+/// fits.
+///
+/// The instance count and the gap count are not the same number, and conflating them is what used to
+/// drop the single instance that fits into a range too short for two.
+///
+private func automaticSpacingPlacement(
+    rangeLength: Double,
+    instanceLength: Double,
+    minimumSpacing: Double,
+    cyclically: Bool
+) -> (count: Int, step: Double)? {
+    guard rangeLength >= instanceLength else {
+        logger.warning("Repeating with a minimum spacing: geometry measuring \(instanceLength) doesn't fit in a range of \(rangeLength). No geometry produced.")
+        return nil
+    }
+
+    if cyclically {
+        // Cyclic spacing leaves a gap after the last instance as well, so every instance costs a full
+        // slot of its own length plus the spacing.
+        let count = Int(floor(rangeLength / (instanceLength + minimumSpacing)))
+        guard count > 0 else {
+            logger.warning("Repeating cyclically with a minimum spacing: a range of \(rangeLength) has no room for an instance and its trailing gap. No geometry produced.")
+            return nil
+        }
+        return (count, rangeLength / Double(count))
+
+    } else {
+        // The first instance takes up its own length; what remains is what further instances have to
+        // fit into, each costing its length plus the spacing. That count is the number of gaps, so
+        // there is one more instance than gaps.
+        let availableLength = rangeLength - instanceLength
+        let count = Int(floor(availableLength / (instanceLength + minimumSpacing))) + 1
+        return (count, count > 1 ? availableLength / Double(count - 1) : 0)
     }
 }

--- a/Sources/Cadova/Abstract Layer/Operations/Duplication/RepeatAlong.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/Duplication/RepeatAlong.swift
@@ -102,12 +102,39 @@ extension Geometry {
     /// The final spacing is adjusted to fill the available range evenly.
     ///
     public func repeated(along axis: D.Axis, in range: ClosedRange<Double>, minimumSpacing: Double, cyclically: Bool = false) -> D.Geometry {
-        measuringBounds { _, bounds in
+        // How many instances fit in the range and how far apart to place them, or `nil` if not even one
+        // fits. The instance count and the gap count are not the same number, and conflating them is what
+        // used to drop the single instance that fits into a range too short for two.
+        @Sendable func automaticSpacingPlacement(rangeLength: Double, instanceLength: Double) -> (count: Int, step: Double)? {
+            guard rangeLength >= instanceLength else {
+                logger.warning("Repeating with a minimum spacing: geometry measuring \(instanceLength) doesn't fit in a range of \(rangeLength). No geometry produced.")
+                return nil
+            }
+
+            if cyclically {
+                // Cyclic spacing leaves a gap after the last instance as well, so every instance costs a
+                // full slot of its own length plus the spacing.
+                let count = Int(floor(rangeLength / (instanceLength + minimumSpacing)))
+                guard count > 0 else {
+                    logger.warning("Repeating cyclically with a minimum spacing: a range of \(rangeLength) has no room for an instance and its trailing gap. No geometry produced.")
+                    return nil
+                }
+                return (count, rangeLength / Double(count))
+
+            } else {
+                // The first instance takes up its own length; what remains is what further instances have
+                // to fit into, each costing its length plus the spacing. That count is the number of gaps,
+                // so there is one more instance than gaps.
+                let availableLength = rangeLength - instanceLength
+                let count = Int(floor(availableLength / (instanceLength + minimumSpacing))) + 1
+                return (count, count > 1 ? availableLength / Double(count - 1) : 0)
+            }
+        }
+
+        return measuringBounds { _, bounds in
             let placement = automaticSpacingPlacement(
                 rangeLength: range.upperBound - range.lowerBound,
-                instanceLength: bounds.size[axis],
-                minimumSpacing: minimumSpacing,
-                cyclically: cyclically
+                instanceLength: bounds.size[axis]
             )
 
             if let placement {
@@ -115,42 +142,5 @@ extension Geometry {
                     .translated(D.Vector(axis, value: range.lowerBound))
             }
         }
-    }
-}
-
-/// Works out how many instances fit in a range and how far apart to put them, or `nil` if not even one
-/// fits.
-///
-/// The instance count and the gap count are not the same number, and conflating them is what used to
-/// drop the single instance that fits into a range too short for two.
-///
-private func automaticSpacingPlacement(
-    rangeLength: Double,
-    instanceLength: Double,
-    minimumSpacing: Double,
-    cyclically: Bool
-) -> (count: Int, step: Double)? {
-    guard rangeLength >= instanceLength else {
-        logger.warning("Repeating with a minimum spacing: geometry measuring \(instanceLength) doesn't fit in a range of \(rangeLength). No geometry produced.")
-        return nil
-    }
-
-    if cyclically {
-        // Cyclic spacing leaves a gap after the last instance as well, so every instance costs a full
-        // slot of its own length plus the spacing.
-        let count = Int(floor(rangeLength / (instanceLength + minimumSpacing)))
-        guard count > 0 else {
-            logger.warning("Repeating cyclically with a minimum spacing: a range of \(rangeLength) has no room for an instance and its trailing gap. No geometry produced.")
-            return nil
-        }
-        return (count, rangeLength / Double(count))
-
-    } else {
-        // The first instance takes up its own length; what remains is what further instances have to
-        // fit into, each costing its length plus the spacing. That count is the number of gaps, so
-        // there is one more instance than gaps.
-        let availableLength = rangeLength - instanceLength
-        let count = Int(floor(availableLength / (instanceLength + minimumSpacing))) + 1
-        return (count, count > 1 ? availableLength / Double(count - 1) : 0)
     }
 }

--- a/Sources/Cadova/Abstract Layer/Operations/Duplication/RepeatAlongPath.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/Duplication/RepeatAlongPath.swift
@@ -117,7 +117,10 @@ public extension Geometry3D {
         precondition(spacing > 0, "Spacing needs to be greater than zero.")
 
         return repeatedInternal(along: path.curve3D, target: target, reference: reference) {
-            (Int(floor($0 / spacing)), spacing)
+            // The instance at distance 0 doesn't consume any spacing, so the number of instances is one
+            // more than the number of whole steps that fit. The epsilon keeps a step that divides the
+            // length evenly from losing its final instance to rounding.
+            (Int(floor($0 / spacing + 1e-9)) + 1, spacing)
         }
     }
 }

--- a/Sources/Cadova/Abstract Layer/Operations/Duplication/RepeatAround.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/Duplication/RepeatAround.swift
@@ -23,9 +23,9 @@ extension Geometry2D {
     @GeometryBuilder2D
     public func repeated(in range: Range<Angle> = 0°..<360°, count: Int) -> any Geometry2D {
         if count > 0 {
-            let step = (range.upperBound - range.lowerBound) / Double(count)
-            for value in stride(from: range.lowerBound.radians, to: range.upperBound.radians, by: step.radians) {
-                rotated(Angle(radians: value))
+            let sweep = range.upperBound - range.lowerBound
+            for i in 0..<count {
+                rotated(range.lowerBound + sweep * (Double(i) / Double(count)))
             }
         }
     }
@@ -40,9 +40,9 @@ extension Geometry2D {
     @GeometryBuilder2D
     public func repeated(in range: ClosedRange<Angle>, count: Int) -> any Geometry2D {
         if count > 1 {
-            let step = (range.upperBound - range.lowerBound) / Double(count - 1)
-            for value in stride(from: range.lowerBound, through: range.upperBound, by: step) {
-                rotated(value)
+            let sweep = range.upperBound - range.lowerBound
+            for i in 0..<count {
+                rotated(range.lowerBound + sweep * (Double(i) / Double(count - 1)))
             }
         } else if count == 1 {
             rotated(range.lowerBound)
@@ -75,9 +75,9 @@ extension Geometry3D {
     @GeometryBuilder3D
     public func repeated(around axis: Axis3D, in range: Range<Angle> = 0°..<360°, count: Int) -> any Geometry3D {
         if count > 0 {
-            let step = (range.upperBound - range.lowerBound) / Double(count)
-            for value in stride(from: range.lowerBound, to: range.upperBound, by: step) {
-                rotated(angle: value, axis: axis)
+            let sweep = range.upperBound - range.lowerBound
+            for i in 0..<count {
+                rotated(angle: range.lowerBound + sweep * (Double(i) / Double(count)), axis: axis)
             }
         }
     }
@@ -92,9 +92,9 @@ extension Geometry3D {
     @GeometryBuilder3D
     public func repeated(around axis: Axis3D, in range: ClosedRange<Angle>, count: Int) -> any Geometry3D {
         if count > 1 {
-            let step = (range.upperBound - range.lowerBound) / Double(count - 1)
-            for value in stride(from: range.lowerBound, through: range.upperBound, by: step) {
-                rotated(angle: value, axis: axis)
+            let sweep = range.upperBound - range.lowerBound
+            for i in 0..<count {
+                rotated(angle: range.lowerBound + sweep * (Double(i) / Double(count - 1)), axis: axis)
             }
         } else if count == 1 {
             rotated(angle: range.lowerBound, axis: axis)

--- a/Tests/Tests/Common/GeometryExtensions.swift
+++ b/Tests/Tests/Common/GeometryExtensions.swift
@@ -57,6 +57,25 @@ extension Geometry {
         }
     }
 
+    /// The number of copies a duplication operation emitted, counted at the node level.
+    ///
+    /// `partCount` and `.separated` both go through `decompose`, which merges copies that touch or
+    /// coincide. That hides exactly the failure mode duplication counts need to be checked against: a
+    /// copy landing on top of another one. The union node's children are neither merged nor
+    /// deduplicated, so counting them reports what the operation actually emitted.
+    ///
+    /// The context is passed in so a sweep over many counts can share one, since building a fresh
+    /// `_EvaluationContext` per call dominates the run time.
+    ///
+    func emittedCopyCount(in context: _EvaluationContext) async throws -> Int {
+        let node = try await context.buildResult(for: withDefaultSegmentation(), in: .defaultEnvironment).node
+        switch node.contents {
+        case .empty: return 0
+        case .boolean(let children, type: .union): return children.count
+        default: return 1
+        }
+    }
+
     var parts: [Part: _BuildResult<D3>] {
         get async throws {
             try await _EvaluationContext().buildModelResult(for: self, in: .defaultEnvironment)

--- a/Tests/Tests/RepeatAlongPath.swift
+++ b/Tests/Tests/RepeatAlongPath.swift
@@ -43,9 +43,10 @@ struct RepeatAlongPathTests {
             .repeated(along: path, spacing: 20)
             .bounds
 
-        // Path length 60, spacing 20: count = floor(60/20) = 3, spheres at 0, 20, 40
+        // Path length 60, spacing 20: spheres at 0, 20, 40 and 60. The one at 60 sits at the very end
+        // of the path, which does not exceed it, so it belongs there.
         #expect(bounds?.minimum.x ≈ -2)
-        #expect(bounds?.maximum.x ≈ 42)
+        #expect(bounds?.maximum.x ≈ 62)
     }
 
     @Test func `3D geometry repeated along curved path`() async throws {

--- a/Tests/Tests/RepeatCounts.swift
+++ b/Tests/Tests/RepeatCounts.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+@testable import Cadova
+
+/// Sweeps over the count-based duplication operations and checks that each one emits exactly the
+/// number of copies it was asked for.
+///
+/// Copies are counted at the node level rather than through `partCount`, because decomposition merges
+/// copies that touch or coincide, which would hide a copy landing exactly on top of another one.
+///
+struct RepeatCountTests {
+    // A fresh `_EvaluationContext` per call dominates the run time of a sweep, so the whole suite
+    // shares one.
+    let context = _EvaluationContext()
+
+    static let sweep = 1...2000
+
+    private static let listedMismatchLimit = 40
+
+    private func expectNoMismatches(_ mismatches: [(requested: Int, emitted: Int)]) {
+        var list = mismatches.prefix(Self.listedMismatchLimit)
+            .map { "\($0.requested)→\($0.emitted)" }
+            .joined(separator: ", ")
+        if mismatches.count > Self.listedMismatchLimit {
+            list += ", …(\(mismatches.count - Self.listedMismatchLimit) more)"
+        }
+        if !mismatches.isEmpty {
+            Issue.record("\(mismatches.count) of \(Self.sweep.count) counts wrong: \(list)")
+        }
+    }
+
+    // MARK: - Angular, half-open range
+
+    @Test func repeatedInHalfOpenAngleRangeEmitsRequestedCount2D() async throws {
+        var mismatches: [(requested: Int, emitted: Int)] = []
+        for count in Self.sweep {
+            let emitted = try await Circle(diameter: 2)
+                .translated(x: 10)
+                .repeated(in: 0°..<360°, count: count)
+                .emittedCopyCount(in: context)
+            if emitted != count { mismatches.append((count, emitted)) }
+        }
+        expectNoMismatches(mismatches)
+    }
+
+    @Test func repeatedInHalfOpenAngleRangeEmitsRequestedCount3D() async throws {
+        var mismatches: [(requested: Int, emitted: Int)] = []
+        for count in Self.sweep {
+            let emitted = try await Box(2)
+                .translated(x: 10)
+                .repeated(around: .z, in: 0°..<360°, count: count)
+                .emittedCopyCount(in: context)
+            if emitted != count { mismatches.append((count, emitted)) }
+        }
+        expectNoMismatches(mismatches)
+    }
+
+    // MARK: - Angular, closed range
+
+    @Test func repeatedInClosedAngleRangeEmitsRequestedCount2D() async throws {
+        var mismatches: [(requested: Int, emitted: Int)] = []
+        for count in Self.sweep {
+            let emitted = try await Circle(diameter: 2)
+                .translated(x: 10)
+                .repeated(in: 0°...180°, count: count)
+                .emittedCopyCount(in: context)
+            if emitted != count { mismatches.append((count, emitted)) }
+        }
+        expectNoMismatches(mismatches)
+    }
+
+    @Test func repeatedInClosedAngleRangeEmitsRequestedCount3D() async throws {
+        var mismatches: [(requested: Int, emitted: Int)] = []
+        for count in Self.sweep {
+            let emitted = try await Box(2)
+                .translated(x: 10)
+                .repeated(around: .z, in: 0°...180°, count: count)
+                .emittedCopyCount(in: context)
+            if emitted != count { mismatches.append((count, emitted)) }
+        }
+        expectNoMismatches(mismatches)
+    }
+
+    // MARK: - Linear
+
+    @Test func repeatedAlongHalfOpenRangeEmitsRequestedCount() async throws {
+        var mismatches: [(requested: Int, emitted: Int)] = []
+        for count in Self.sweep {
+            let emitted = try await Box(1)
+                .repeated(along: .x, in: 0..<100, count: count)
+                .emittedCopyCount(in: context)
+            if emitted != count { mismatches.append((count, emitted)) }
+        }
+        expectNoMismatches(mismatches)
+    }
+
+    @Test func repeatedAlongClosedRangeEmitsRequestedCount() async throws {
+        var mismatches: [(requested: Int, emitted: Int)] = []
+        for count in Self.sweep {
+            let emitted = try await Box(1)
+                .repeated(along: .x, in: 0...100, count: count)
+                .emittedCopyCount(in: context)
+            if emitted != count { mismatches.append((count, emitted)) }
+        }
+        expectNoMismatches(mismatches)
+    }
+
+    // MARK: - The last copy in a closed range lands on the upper bound
+
+    @Test func closedRangeLastCopyLandsExactlyOnUpperBound() async throws {
+        // A step multiplied out `count - 1` times misses the upper bound by an ulp or two, which is
+        // enough to drop the last copy entirely: 100 / 11 * 11 overshoots 100. The offsets are read
+        // off the nodes because the measured bounds go through Manifold's single-precision
+        // arithmetic, which rounds a miss this small away.
+        let upperBound = 100.0
+        let node = try await context.buildResult(
+            for: Box(1).repeated(along: .x, in: 0...upperBound, count: 12).withDefaultSegmentation(),
+            in: .defaultEnvironment
+        ).node
+
+        guard case .boolean(let children, type: .union) = node.contents else {
+            Issue.record("Expected a union of copies")
+            return
+        }
+
+        let offsets = children.compactMap { child -> Double? in
+            guard case .transform(_, let transform) = child.contents else { return nil }
+            return transform.offset.x
+        }
+        #expect(offsets.max() == upperBound)
+    }
+
+    // MARK: - Minimum spacing
+
+    @Test func minimumSpacingKeepsTheSingleInstanceThatFits() async throws {
+        // A 5 wide box in a range of 8 with a minimum spacing of 2: one instance fits, two don't.
+        let geometry = Box(5).repeated(along: .x, in: 0...8, minimumSpacing: 2)
+        #expect(try await geometry.emittedCopyCount(in: context) == 1)
+
+        let bounds = try await geometry.bounds
+        #expect(bounds?.minimum.x ≈ 0)
+        #expect(bounds?.maximum.x ≈ 5)
+    }
+
+    @Test func minimumSpacingCyclicallyKeepsTheSingleInstanceThatFits() async throws {
+        let geometry = Box(5).repeated(along: .x, in: 0...8, minimumSpacing: 2, cyclically: true)
+        #expect(try await geometry.emittedCopyCount(in: context) == 1)
+    }
+
+    @Test func minimumSpacingProducesNothingWhenTheGeometryDoesNotFit() async throws {
+        let geometry = Box(5).repeated(along: .x, in: 0...4, minimumSpacing: 2)
+        #expect(try await geometry.emittedCopyCount(in: context) == 0)
+    }
+
+    @Test func minimumSpacingSpansTheWholeRangeWhenSeveralFit() async throws {
+        // A 5 wide box in a range of 50 with a minimum spacing of 3: available is 45, each further
+        // instance costs 8, so 6 instances fit and the last one ends at the upper bound.
+        let geometry = Box(5).repeated(along: .x, in: 0...50, minimumSpacing: 3)
+        #expect(try await geometry.emittedCopyCount(in: context) == 6)
+
+        let bounds = try await geometry.bounds
+        #expect(bounds?.minimum.x ≈ 0)
+        #expect(bounds?.maximum.x ≈ 50)
+    }
+
+    // MARK: - Along a path with fixed spacing
+
+    @Test func repeatedAlongPathWithSpacingIncludesTheInstanceAtTheEnd() async throws {
+        let path = BezierPath3D {
+            line(x: 10)
+        }
+
+        // Instances go at 0, 5 and 10; 10 does not exceed the path length.
+        let geometry = Sphere(diameter: 2).repeated(along: path, spacing: 5)
+        #expect(try await geometry.emittedCopyCount(in: context) == 3)
+
+        let bounds = try await geometry.bounds
+        #expect(bounds?.minimum.x ≈ -1)
+        #expect(bounds?.maximum.x ≈ 11)
+    }
+
+    @Test func repeatedAlongPathWithSpacingStopsBeforeExceedingTheLength() async throws {
+        let path = BezierPath3D {
+            line(x: 12)
+        }
+
+        // Instances go at 0, 5 and 10; 15 would exceed the path length.
+        let geometry = Sphere(diameter: 2).repeated(along: path, spacing: 5)
+        #expect(try await geometry.emittedCopyCount(in: context) == 3)
+    }
+}


### PR DESCRIPTION
Three separate ways the repeat operations place the wrong number of copies.

**Count-based overloads emit one too many or one too few.** All six of them derive a step and then walk it with a floating-point `stride`. `stride` compares `start + step*i` against the bound, so whether the last sample falls inside is decided by how the step rounded. Measured over counts 1 through 2000:

| overload | wrong counts |
|---|---|
| 2D, `0°..<360°` | 357 |
| 3D, `0°..<360°` | 53 |
| 2D and 3D, `0°...180°` | 34 each |
| linear, `0.0..<100.0` | 85 |
| linear, `0.0...100.0` | 108 |

The two angular forms differ because 3D strides over `Angle` while 2D strides over raw `Double` radians.

A count that comes out one high in a full-circle pattern puts the extra copy exactly on top of the first, so a 39-spoke wheel silently gets a doubled spoke and a self-union of coincident geometry. One that comes out short drops the copy on the upper bound that the `ClosedRange` doc comment explicitly promises. The overloads now iterate `0..<count` and compute each position as a fraction of the span, which also lands the last sample exactly on the bound instead of near it.

**`repeated(along:in:minimumSpacing:)` produces nothing when exactly one instance fits.** It counted gaps and used that as the instance count, so a range long enough for one instance but not two took the `count > 0` branch as false and returned empty. Instance count and gap count are now separated. A range too short for even one instance returns empty with a warning rather than silently. The `cyclically: true` branch turned out not to have this bug, since its count is already an instance count; it only gained the shared fit guard.

**`repeated(along path:spacing:)` drops the last instance.** It placed `floor(length / spacing)` instances, one short of the `0, spacing, 2*spacing, ...` up to the path length that its documentation describes. A 10 mm path at spacing 5 now gets instances at 0, 5 and 10.

Copies are counted in the tests at the node level rather than through `partCount`, because decomposition merges coincident copies and would hide the doubled-spoke case entirely.

One existing test changes. `"3D geometry repeated along path with spacing only fills path"` encoded the off-by-one from the third item: a 60 mm path at spacing 20 was expected to end at 42 rather than 62. Its comment spelled the old arithmetic out, so this was deliberate at the time; the instance at 60 does not exceed the path length, so it belongs there.
