### PR TITLE
Fix traps and silent corruption on degenerate curve inputs

### DIFF
--- a/Sources/Cadova/Values/Curves/Bezier/BezierCurve.swift
+++ b/Sources/Cadova/Values/Curves/Bezier/BezierCurve.swift
@@ -25,8 +25,40 @@ internal struct BezierCurve<V: Vector>: Sendable, Hashable, Codable {
         BezierCurve(controlPoints: controlPoints.paired().map { ($1 - $0) * Double(degree) })
     }
 
+    /// The largest distance from the first control point to any other. Used as the curve's own length
+    /// scale, so tolerances below are relative rather than assuming millimetre-sized geometry.
+    private var controlPolygonExtent: Double {
+        controlPoints.dropFirst().reduce(0) { Swift.max($0, controlPoints[0].distance(to: $1)) }
+    }
+
+    /// The direction of travel at `fraction`.
+    ///
+    /// Ordinarily this is just the first derivative, but a curve whose control points coincide at that
+    /// end has a first derivative of exactly zero there — a cubic leaving its start point with no
+    /// tension is a perfectly ordinary way to author a curve — and `Direction` would normalize that zero
+    /// vector into a zero-length "unit" direction without complaint, producing a frame with no Z axis or
+    /// a plane with no normal further downstream.
+    ///
+    /// L'Hôpital's rule gives the true tangent as the first derivative that doesn't vanish, so fall back
+    /// to the second, and finally to the chord across the whole curve.
     func tangent(at fraction: Double) -> Direction<V.D> {
-        Direction(derivative.point(at: fraction))
+        guard controlPoints.count > 1 else { return .undefined }
+        let epsilon = controlPolygonExtent * 1e-9
+
+        let firstDerivative = derivative
+        let velocity = firstDerivative.point(at: fraction)
+        if velocity.magnitude > epsilon { return Direction(velocity) }
+
+        if firstDerivative.controlPoints.count > 1 {
+            // B'(t₀ + h) ≈ B''(t₀)·h, so B'' gives the direction of travel for h > 0. At the very end of
+            // the curve the only h available points backwards, and the sign flips with it.
+            let sign: Double = fraction >= 1 ? -1 : 1
+            let acceleration = firstDerivative.derivative.point(at: fraction) * sign
+            if acceleration.magnitude > epsilon { return Direction(acceleration) }
+        }
+
+        let chord = controlPoints.last! - controlPoints.first!
+        return chord.magnitude > epsilon ? Direction(chord) : .undefined
     }
 
     private func points(in range: Range<Double>, segmentLength: Double) -> [(Double, V)] {
@@ -54,7 +86,13 @@ internal struct BezierCurve<V: Vector>: Sendable, Hashable, Codable {
     }
 
     func points(in range: Range<Double> = 0..<1, segmentation: Segmentation, subdividingStraightLines: Bool) -> [(Double, V)] {
-        guard subdividingStraightLines || controlPoints.count > 2 else {
+        // A curve collapsed onto a single control point (from `subcurve(in:)` over a degenerate range)
+        // is that point everywhere; it has no interior to sample and no second control point to read.
+        if controlPoints.count == 1 {
+            return [(range.lowerBound, controlPoints[0]), (range.upperBound, controlPoints[0])]
+        }
+
+        if !subdividingStraightLines, controlPoints.count == 2 {
             let p1 = controlPoints[0] + (controlPoints[1] - controlPoints[0]) * range.lowerBound
             let p2 = controlPoints[0] + (controlPoints[1] - controlPoints[0]) * range.upperBound
             return [(range.lowerBound, p1), (range.upperBound, p2)]

--- a/Sources/Cadova/Values/Curves/Bezier/BezierCurve.swift
+++ b/Sources/Cadova/Values/Curves/Bezier/BezierCurve.swift
@@ -40,7 +40,8 @@ internal struct BezierCurve<V: Vector>: Sendable, Hashable, Codable {
     /// a plane with no normal further downstream.
     ///
     /// L'Hôpital's rule gives the true tangent as the first derivative that doesn't vanish, so fall back
-    /// to the second, and finally to the chord across the whole curve.
+    /// to the second, and finally to the chord across the whole curve. A curve that is genuinely a single
+    /// point has no direction at all, and reports `Direction.undefined`.
     func tangent(at fraction: Double) -> Direction<V.D> {
         guard controlPoints.count > 1 else { return .undefined }
         let epsilon = controlPolygonExtent * 1e-9
@@ -57,6 +58,8 @@ internal struct BezierCurve<V: Vector>: Sendable, Hashable, Codable {
             if acceleration.magnitude > epsilon { return Direction(acceleration) }
         }
 
+        // Below the threshold the chord is numerical dust, and normalizing it would amplify that
+        // noise into a full-length unit vector pointing nowhere meaningful.
         let chord = controlPoints.last! - controlPoints.first!
         return chord.magnitude > epsilon ? Direction(chord) : .undefined
     }

--- a/Sources/Cadova/Values/Curves/Bezier/BezierPath+Internal.swift
+++ b/Sources/Cadova/Values/Curves/Bezier/BezierPath+Internal.swift
@@ -24,17 +24,30 @@ internal extension BezierPath {
 
     func subpath(in range: ClosedRange<Double>) -> BezierPath {
         guard !isEmpty else { return self }
-        let (lowerIndex, lowerFraction) = curveIndexAndFraction(for: range.lowerBound)
-        var (upperIndex, upperFraction) = curveIndexAndFraction(for: range.upperBound)
 
-        if upperIndex > 0, upperFraction < Double.ulpOfOne {
-            upperIndex -= 1
-            upperFraction = 1.0
+        // A collapsed range selects no curve at all. Say so with a curveless path carrying the point the
+        // range collapsed onto, rather than fabricating a curve index span (which inverts, and traps) or
+        // a single-control-point curve (which sampling then reads out of bounds).
+        guard range.length > .ulpOfOne else {
+            return BezierPath(startPoint: point(at: range.lowerBound), curves: [])
         }
 
-        let newCurves: [BezierCurve<V>] = (lowerIndex...upperIndex).map { i in
+        let (lowerIndex, lowerFraction) = curveIndexAndFraction(for: range.lowerBound)
+        let (upperIndex, upperFraction) = curveIndexAndFraction(for: range.upperBound)
+
+        // A range ending exactly on a curve boundary belongs to the end of the preceding curve, not to a
+        // zero-length piece of the next one. The guard above makes this safe: the range spans more than
+        // one curve whenever the pull-back applies, so `lastIndex` can never fall below `lowerIndex`.
+        var lastIndex = upperIndex
+        var lastFraction = upperFraction
+        if lastFraction < .ulpOfOne, lastIndex > lowerIndex {
+            lastIndex -= 1
+            lastFraction = 1.0
+        }
+
+        let newCurves: [BezierCurve<V>] = (lowerIndex...lastIndex).map { i in
             let start = (i == lowerIndex) ? lowerFraction : 0
-            let end = (i == upperIndex) ? upperFraction : 1
+            let end = (i == lastIndex) ? lastFraction : 1
             return (start == 0 && end == 1) ? curves[i] : curves[i].subcurve(in: start...end)
         }
         let newStartPoint = newCurves.first?.controlPoints[0] ?? startPoint

--- a/Sources/Cadova/Values/Curves/Bezier/BezierPath.swift
+++ b/Sources/Cadova/Values/Curves/Bezier/BezierPath.swift
@@ -120,7 +120,7 @@ extension BezierPath: ParametricCurve {
     }
 
     public var derivativeView: any CurveDerivativeView<V> {
-        BezierPathDerivativeView(derivative: derivative)
+        BezierPathDerivativeView(path: self)
     }
 
     /// Returns points sampled along a parameter subrange.
@@ -144,10 +144,15 @@ extension BezierPath: ParametricCurve {
 }
 
 internal struct BezierPathDerivativeView<V: Vector>: CurveDerivativeView {
-    let derivative: BezierPath<V>
+    let path: BezierPath<V>
 
+    /// Defers to the containing curve's own `tangent(at:)` rather than normalizing a point off the
+    /// derivative path directly, so a vanishing derivative at a coincident control point is resolved
+    /// there instead of becoming a zero-length "unit" direction here.
     func tangent(at u: Double) -> Direction<V.D> {
-        Direction(derivative.point(at: u))
+        guard !path.isEmpty else { return .undefined }
+        let (curveIndex, fraction) = path.curveIndexAndFraction(for: u)
+        return path.curves[curveIndex].tangent(at: fraction)
     }
 }
 

--- a/Sources/Cadova/Values/Curves/FiniteDifferenceTangent.swift
+++ b/Sources/Cadova/Values/Curves/FiniteDifferenceTangent.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Finds a tangent direction by sampling a curve either side of `u`, widening the sampling window until
+/// the difference between the samples rises above floating-point noise.
+///
+/// A plain central difference is fine almost everywhere and wrong exactly where it matters. It vanishes
+/// identically wherever a curve is momentarily stationary — a repeated control point, a segment
+/// collapsed onto a single position — and cancels to rounding noise where a curve reverses on itself.
+/// `Direction` normalizes whatever it is handed, so the result there is either a zero-length "unit"
+/// vector or a unit vector made entirely of rounding error. Neither is detectable downstream: the
+/// frame, plane or sweep built from it is simply, silently wrong.
+///
+/// The fallbacks, in order: a wider central difference, then a one-sided difference (at a cusp the two
+/// sides cancel exactly, but each side on its own is a real direction), then the chord across the whole
+/// curve.
+///
+/// - Parameters:
+///   - u: The parameter to evaluate the tangent at.
+///   - domain: The curve's parameter domain. Samples are never taken outside it.
+///   - baseStep: The initial half-width of the sampling window, in parameter units.
+///   - point: The curve's point function.
+/// - Returns: A unit direction, or ``Direction/undefined`` for a curve that is a single point and so
+///   has no tangent at all.
+///
+internal func finiteDifferenceTangent<V: Vector>(
+    at u: Double,
+    over domain: ClosedRange<Double>,
+    baseStep: Double,
+    point: (Double) -> V
+) -> Direction<V.D> {
+    // Significance is measured relative to the coordinates themselves, so the threshold scales with the
+    // model rather than assuming millimetre-sized geometry. 1e-12 sits a few thousand ulps above the
+    // rounding error of the subtraction, which is comfortably below any difference that carries shape.
+    func isSignificant(_ a: V, _ b: V) -> Bool {
+        (b - a).magnitude > Swift.max(a.magnitude, b.magnitude, .leastNormalMagnitude) * 1e-12
+    }
+
+    let center = point(u)
+
+    for step in [baseStep, baseStep * 100, baseStep * 10_000] {
+        let before = point((u - step).clamped(to: domain))
+        let after = point((u + step).clamped(to: domain))
+
+        if isSignificant(before, after) { return Direction(after - before) }
+        // Look forward first, matching the curve's own direction of travel.
+        if isSignificant(center, after) { return Direction(after - center) }
+        if isSignificant(before, center) { return Direction(center - before) }
+    }
+
+    let start = point(domain.lowerBound)
+    let end = point(domain.upperBound)
+    return isSignificant(start, end) ? Direction(end - start) : .undefined
+}

--- a/Sources/Cadova/Values/Curves/FiniteDifferenceTangent.swift
+++ b/Sources/Cadova/Values/Curves/FiniteDifferenceTangent.swift
@@ -19,7 +19,7 @@ import Foundation
 ///   - domain: The curve's parameter domain. Samples are never taken outside it.
 ///   - baseStep: The initial half-width of the sampling window, in parameter units.
 ///   - point: The curve's point function.
-/// - Returns: A unit direction, or ``Direction/undefined`` for a curve that is a single point and so
+/// - Returns: A unit direction, or `Direction.undefined` for a curve that is a single point and so
 ///   has no tangent at all.
 ///
 internal func finiteDifferenceTangent<V: Vector>(

--- a/Sources/Cadova/Values/Curves/InterpolatingCurve.swift
+++ b/Sources/Cadova/Values/Curves/InterpolatingCurve.swift
@@ -62,9 +62,12 @@ public struct InterpolatingCurve<V: Vector>: ParametricCurve, Sendable, Hashable
         let t3 = t2 + dt(p2, p3)
         let t = t1 + localFraction * (t2 - t1)
 
-        // Tangents (general CR with centripetal times)
-        let m1 = (p2 - p0) * (1.0 / max(t2, .leastNonzeroMagnitude))
-        let m2 = (p3 - p1) * (1.0 / max(t3 - t1, .leastNonzeroMagnitude))
+        // Tangents (general CR with centripetal times). The floor is `leastNormalMagnitude` rather than
+        // `leastNonzeroMagnitude` because the reciprocal of a subnormal overflows to infinity, and
+        // coincident control points make these times exactly zero: 0 × ∞ is NaN, which then propagates
+        // into every point on the segment.
+        let m1 = (p2 - p0) * (1.0 / max(t2, .leastNormalMagnitude))
+        let m2 = (p3 - p1) * (1.0 / max(t3 - t1, .leastNormalMagnitude))
 
         // Cubic Hermite basis over s in [0,1]
         let s = (t - t1) / max(t2 - t1, .leastNonzeroMagnitude)
@@ -190,10 +193,10 @@ extension InterpolatingCurve: Transformable {
 internal struct InterpolatingCurveDerivativeView<V: Vector>: CurveDerivativeView {
     let curve: InterpolatingCurve<V>
 
+    /// Two coincident control points collapse a whole segment onto a single position, where a plain
+    /// difference is exactly zero; ``finiteDifferenceTangent(at:over:baseStep:point:)`` widens the
+    /// sampling window until it finds real geometry instead of normalizing that zero.
     func tangent(at u: Double) -> Direction<V.D> {
-        Direction(
-            from: curve.point(at: (u - 1e-6).clamped(to: curve.domain)),
-            to: curve.point(at: (u + 1e-6).clamped(to: curve.domain))
-        )
+        finiteDifferenceTangent(at: u, over: curve.domain, baseStep: 1e-6, point: curve.point(at:))
     }
 }

--- a/Sources/Cadova/Values/Curves/ParametricCurveFrame/ParametricCurveFrame+Sequence.swift
+++ b/Sources/Cadova/Values/Curves/ParametricCurveFrame/ParametricCurveFrame+Sequence.swift
@@ -1,24 +1,39 @@
 import Foundation
 
 extension [ParametricCurveFrame] {
+    /// Fills in frames whose reference/target alignment was momentarily degenerate, by interpolating
+    /// between the resolved angles bracketing each run.
+    ///
+    /// The bounding angles are deliberately *not* treated as an ordered pair. They come straight from
+    /// `atan2` and land anywhere in (-180°, 180°] in whatever order the curve happens to produce;
+    /// `normalizeAngles()` only monotonizes them afterwards, so a run whose preceding angle is larger
+    /// than its following one is entirely ordinary here.
     mutating func interpolateMissingAngles() {
         var offset = 0
         while let start = self[offset...].firstIndex(where: { $0.angle == nil }) {
             let end = self[start...].firstIndex(where: { $0.angle != nil })
+            let missingIndexes = start..<(end ?? count)
 
-            let resolvedIndexes = start..<(end ?? count)
-            let resolvedRange: Range<Angle>
-
+            // A run at the very start of the sequence extends the following known angle backwards, and a
+            // run at the very end extends the preceding one forwards. Both fall out of the shared
+            // interpolation below as a zero step, since their two bounds are the same angle.
+            let lowerAngle: Angle
+            let upperAngle: Angle
             if start == 0 {
-                let value = end.map { self[$0].angle! } ?? 0°
-                resolvedRange = value..<value
+                lowerAngle = end.map { self[$0].angle! } ?? 0°
+                upperAngle = lowerAngle
             } else {
-                resolvedRange = (self[start - 1].angle!)..<(self[end ?? start - 1].angle!)
+                lowerAngle = self[start - 1].angle!
+                upperAngle = end.map { self[$0].angle! } ?? lowerAngle
             }
 
-            let step = resolvedRange.length / Double(resolvedIndexes.length)
-            for i in resolvedIndexes {
-                self[i].angle = resolvedRange.lowerBound + Double(i - resolvedIndexes.lowerBound) * step
+            // The shortest signed arc, so a run spanning the ±180° seam takes the short way round rather
+            // than unwinding nearly a full turn. Interpolating k interior angles between two known ones
+            // divides the arc into k + 1 steps: the missing frames sit strictly between their bounds
+            // rather than duplicating the preceding one and stopping short of the following one.
+            let step = (upperAngle - lowerAngle).normalized / Double(missingIndexes.count + 1)
+            for (position, index) in missingIndexes.enumerated() {
+                self[index].angle = lowerAngle + step * Double(position + 1)
             }
 
             if let end {

--- a/Sources/Cadova/Values/Curves/Spline Curve/SplineCurve.swift
+++ b/Sources/Cadova/Values/Curves/Spline Curve/SplineCurve.swift
@@ -86,11 +86,17 @@ public struct SplineCurve<V: Vector>: Sendable, Hashable, Codable {
     }
     
     /// Tangent direction via finite difference. Suitable for framing and sampling.
+    ///
+    /// Repeated control points can leave the curve stationary across a whole knot span, where a plain
+    /// difference is exactly zero; ``finiteDifferenceTangent(at:over:baseStep:point:)`` widens the
+    /// sampling window until it finds real geometry instead of normalizing that zero.
     public func tangent(at u: Double) -> Direction<V.D> {
-        let eps = max(1e-6, 1e-6 * domain.length)
-        let a = point(at: (u - eps).clamped(to: domain))
-        let b = point(at: (u + eps).clamped(to: domain))
-        return Direction(b - a)
+        finiteDifferenceTangent(
+            at: u,
+            over: domain,
+            baseStep: max(1e-6, 1e-6 * domain.length),
+            point: point(at:)
+        )
     }
     
     /// Reversed curve (parameterization flipped). Knots, control points, and weights are mirrored accordingly.

--- a/Sources/Cadova/Values/Spatial/Direction.swift
+++ b/Sources/Cadova/Values/Spatial/Direction.swift
@@ -13,6 +13,17 @@ public struct Direction<D: Dimensionality>: Hashable, Sendable, Codable {
     }
 }
 
+internal extension Direction {
+    /// A deterministic stand-in for a direction that is genuinely undefined, such as the tangent of a
+    /// curve that has collapsed to a single point.
+    ///
+    /// `Direction`'s contract is that `unitVector` has unit length, so there is no honest "no direction"
+    /// value to return. Normalizing a zero vector yields the zero vector back (see `Vector.normalized`),
+    /// which passes silently as a direction and then propagates as a degenerate frame basis or a plane
+    /// with no normal. Producing a valid, arbitrary direction at least keeps the invariant intact.
+    static var undefined: Self { Self(D.Axis.allCases.first!, .positive) }
+}
+
 /// A direction in three-dimensional space.
 public typealias Direction3D = Direction<D3>
 

--- a/Sources/Cadova/Values/Spatial/Direction.swift
+++ b/Sources/Cadova/Values/Spatial/Direction.swift
@@ -1,27 +1,38 @@
 /// A unit-length direction vector in a given dimensionality.
 ///
 /// `Direction` represents only the orientation of a vector, not its magnitude.
-/// All directions are normalized upon creation.
+/// Directions are normalized upon creation, with one exception: a zero-length vector has no
+/// orientation to extract, and gives ``undefined``. Curve tangents report that where the geometry has
+/// no direction, such as a curve collapsed onto a single point. Check for it with ``isUndefined``.
 public struct Direction<D: Dimensionality>: Hashable, Sendable, Codable {
     /// The normalized vector representing the direction.
     public let unitVector: D.Vector
 
     /// Creates a new direction by normalizing the provided vector.
+    ///
+    /// Passing a zero-length vector yields ``undefined`` rather than a unit direction, since there is
+    /// no orientation to extract.
+    ///
     /// - Parameter vector: The vector whose direction is used.
     public init(_ vector: D.Vector) {
         self.unitVector = vector.normalized
     }
 }
 
-internal extension Direction {
-    /// A deterministic stand-in for a direction that is genuinely undefined, such as the tangent of a
-    /// curve that has collapsed to a single point.
+public extension Direction {
+    /// The value reported where there is no direction to represent, such as the tangent of a curve
+    /// that has collapsed to a single point, or of an empty path.
     ///
-    /// `Direction`'s contract is that `unitVector` has unit length, so there is no honest "no direction"
-    /// value to return. Normalizing a zero vector yields the zero vector back (see `Vector.normalized`),
-    /// which passes silently as a direction and then propagates as a degenerate frame basis or a plane
-    /// with no normal. Producing a valid, arbitrary direction at least keeps the invariant intact.
-    static var undefined: Self { Self(D.Axis.allCases.first!, .positive) }
+    /// Its `unitVector` is the zero vector, making this the one `Direction` that isn't unit length.
+    /// A frame, plane or transform built from it is degenerate, so where a curve may be degenerate,
+    /// test with ``isUndefined`` before using the result.
+    static var undefined: Self { Self(D.Vector.zero) }
+
+    /// Whether this is ``undefined``.
+    ///
+    /// Equivalent to `self == .undefined`. The test is exact: any vector of usable length normalizes
+    /// to unit length, so a direction never lands near zero without being zero.
+    var isUndefined: Bool { unitVector == .zero }
 }
 
 /// A direction in three-dimensional space.

--- a/Tests/Tests/CurveDegenerateInputs.swift
+++ b/Tests/Tests/CurveDegenerateInputs.swift
@@ -1,0 +1,204 @@
+import Testing
+import Foundation
+@testable import Cadova
+
+/// Regressions for degenerate curve inputs: frame runs with no resolvable twist angle, collapsed
+/// parameter ranges, and curves whose tangent vanishes where control points coincide.
+struct CurveDegenerateInputTests {
+
+    // MARK: - Frame angle interpolation
+
+    /// A frame carrying only the fields `interpolateMissingAngles()` reads.
+    private static func frame(t: Double, angle: Angle?) -> ParametricCurveFrame {
+        ParametricCurveFrame(
+            t: t,
+            distance: t,
+            point: Vector3D(t, 0, 0),
+            xAxis: Vector3D(0, 1, 0),
+            yAxis: Vector3D(0, 0, 1),
+            zAxis: Vector3D(1, 0, 0),
+            angle: angle,
+            miterStretch: nil
+        )
+    }
+
+    private static func interpolatedAngles(_ angles: [Angle?]) -> [Angle] {
+        var frames = angles.enumerated().map { frame(t: Double($0.offset), angle: $0.element) }
+        frames.interpolateMissingAngles()
+        return frames.map { $0.angle! }
+    }
+
+    @Test func `missing frame angles are spaced evenly strictly between the bounding known angles`() {
+        #expect(Self.interpolatedAngles([0°, nil, nil, nil, 40°]) ≈ [0°, 10°, 20°, 30°, 40°])
+    }
+
+    @Test func `a single missing frame angle lands halfway between its neighbours`() {
+        #expect(Self.interpolatedAngles([20°, nil, 50°]) ≈ [20°, 35°, 50°])
+    }
+
+    @Test func `missing frame angles take the short way around the plus minus 180 degree seam`() {
+        // 170° → -170° is a +20° step the short way round; the long way would unwind 340°.
+        #expect(Self.interpolatedAngles([170°, nil, -170°]) ≈ [170°, 180°, -170°])
+    }
+
+    @Test func `a descending run of missing frame angles interpolates downwards`() {
+        // A descending pair used to build an inverted Range<Angle> and trap.
+        #expect(Self.interpolatedAngles([90°, nil, nil, 0°]) ≈ [90°, 60°, 30°, 0°])
+    }
+
+    @Test func `a missing run at the start of the sequence adopts the first known angle`() {
+        #expect(Self.interpolatedAngles([nil, nil, 30°, 60°]) ≈ [30°, 30°, 30°, 60°])
+    }
+
+    @Test func `a missing run at the end of the sequence keeps the last known angle`() {
+        #expect(Self.interpolatedAngles([30°, 60°, nil, nil]) ≈ [30°, 60°, 60°, 60°])
+    }
+
+    @Test func `a sequence with no known angles resolves to zero`() {
+        #expect(Self.interpolatedAngles([nil, nil, nil]) ≈ [0°, 0°, 0°])
+    }
+
+    @Test func `several separate missing runs are each interpolated`() {
+        #expect(Self.interpolatedAngles([0°, nil, 20°, nil, 40°]) ≈ [0°, 10°, 20°, 30°, 40°])
+    }
+
+    // MARK: - Collapsed parameter ranges
+
+    private static var twoCurvePath: BezierPath2D {
+        BezierPath2D(startPoint: [0, 0])
+            .addingCubicCurve(controlPoint1: [0, 10], controlPoint2: [10, 10], end: [10, 0])
+            .addingLine(to: [20, 0])
+    }
+
+    @Test func `sampling a collapsed range at a curve boundary yields that single point`() {
+        // (1...1) used to pull upperIndex below lowerIndex and trap on an inverted Int range.
+        #expect(Self.twoCurvePath.points(in: 1...1, segmentation: .fixed(4)) ≈ [[10, 0]])
+    }
+
+    @Test func `sampling a collapsed range inside a curve yields that single point`() {
+        // This used to fabricate a one-control-point curve, which points() then indexed out of range.
+        let path = Self.twoCurvePath
+        #expect(path.points(in: 0.5...0.5, segmentation: .fixed(4)) ≈ [path.point(at: 0.5)])
+    }
+
+    @Test func `sampling a collapsed range at the end of the path yields that single point`() {
+        #expect(Self.twoCurvePath.points(in: 2...2, segmentation: .fixed(4)) ≈ [[20, 0]])
+    }
+
+    @Test func `a subcurve collapsed onto a point is not sampled as a line`() {
+        let curve = BezierPath2D.Curve(controlPoints: [[0, 0], [10, 0]]).subcurve(in: 0.25...0.25)
+        #expect(curve.controlPoints.count == 1)
+        let points = curve.points(segmentation: .fixed(4), subdividingStraightLines: false).map(\.1)
+        #expect(points ≈ [[2.5, 0], [2.5, 0]])
+    }
+
+    @Test func `sampling ordinary subranges is unaffected`() {
+        #expect(Self.twoCurvePath.points(in: 0...1, segmentation: .fixed(2)) ≈ [[0, 0], [5, 7.5], [10, 0]])
+        // The second curve is a straight line, which points() deliberately does not subdivide.
+        #expect(Self.twoCurvePath.points(in: 1...2, segmentation: .fixed(2)) ≈ [[10, 0], [20, 0]])
+        #expect(Self.twoCurvePath.points(in: 0.5...1.5, segmentation: .fixed(2)) ≈ [[5, 7.5], [8.4375, 5.625], [10, 0], [15, 0]])
+    }
+
+    // MARK: - Vanishing tangents
+
+    @Test func `a cubic leaving its start point with no tension has a unit tangent`() {
+        // P0 == P1, so B'(0) is exactly zero; the true tangent comes from B''(0).
+        let curve = BezierPath2D.Curve(controlPoints: [[0, 0], [0, 0], [10, 0], [10, 10]])
+        let tangent = curve.tangent(at: 0)
+        #expect(tangent.unitVector.magnitude ≈ 1)
+        #expect(tangent ≈ Direction2D(x: 1, y: 0))
+    }
+
+    @Test func `a cubic reaching its end point with no tension has a unit tangent`() {
+        // P2 == P3, so B'(1) is exactly zero. B''(1) points backwards along the travel direction here,
+        // since the end can only be approached from inside the curve.
+        let curve = BezierPath2D.Curve(controlPoints: [[0, 0], [0, 10], [10, 10], [10, 10]])
+        let tangent = curve.tangent(at: 1)
+        #expect(tangent.unitVector.magnitude ≈ 1)
+        #expect(tangent ≈ Direction2D(x: 1, y: 0))
+    }
+
+    @Test func `a 3D cubic with a coincident start pair has a unit tangent`() {
+        let curve = BezierPath3D.Curve(controlPoints: [[0, 0, 0], [0, 0, 0], [0, 0, 10], [5, 0, 10]])
+        let tangent = curve.tangent(at: 0)
+        #expect(tangent.unitVector.magnitude ≈ 1)
+        #expect(tangent ≈ Direction3D(x: 0, y: 0, z: 1))
+    }
+
+    @Test func `a straight line collapsed to a point falls back to a unit tangent`() {
+        let curve = BezierPath2D.Curve(controlPoints: [[3, 4], [3, 4]])
+        #expect(curve.tangent(at: 0.5).unitVector.magnitude ≈ 1)
+    }
+
+    @Test func `a path end direction is unit length when the last curve has no end tension`() {
+        let path = BezierPath2D(startPoint: [0, 0])
+            .addingCubicCurve(controlPoint1: [0, 10], controlPoint2: [10, 10], end: [10, 10])
+        let direction = try! #require(path.endDirection)
+        #expect(direction.unitVector.magnitude ≈ 1)
+        #expect(direction ≈ Direction2D(x: 1, y: 0))
+    }
+
+    @Test func `a path derivative view reports a unit tangent at a coincident control point`() {
+        let path = BezierPath2D(startPoint: [0, 0])
+            .addingCubicCurve(controlPoint1: [0, 0], controlPoint2: [10, 0], end: [10, 10])
+        let tangent = path.derivativeView.tangent(at: 0)
+        #expect(tangent.unitVector.magnitude ≈ 1)
+        #expect(tangent ≈ Direction2D(x: 1, y: 0))
+    }
+
+    @Test func `ordinary bezier tangents are unchanged`() {
+        let curve = BezierPath2D.Curve(controlPoints: [[0, 0], [0, 10], [10, 10], [10, 0]])
+        #expect(curve.tangent(at: 0) ≈ Direction2D(x: 0, y: 1))
+        #expect(curve.tangent(at: 1) ≈ Direction2D(x: 0, y: -1))
+        #expect(curve.tangent(at: 0.5) ≈ Direction2D(x: 1, y: 0))
+    }
+
+    @Test func `an interpolating curve with a repeated point stays finite`() {
+        // Coincident points make the centripetal times zero, and the reciprocal of the subnormal floor
+        // guarding that division used to overflow to infinity, turning every point on the segment NaN.
+        let curve = InterpolatingCurve<Vector2D>(through: [[0, 0], [0, 0], [10, 0]])
+        let points = curve.points(segmentation: .fixed(8))
+        #expect(points.allSatisfy { $0.x.isFinite && $0.y.isFinite })
+        #expect(points.first ≈ [0, 0])
+        #expect(points.last ≈ [10, 0])
+    }
+
+    @Test func `an interpolating curve stalled by a repeated point still has a unit tangent`() {
+        // The first two points coincide, so the whole first segment collapses to a single point and a
+        // finite difference across it is exactly zero.
+        let curve = InterpolatingCurve<Vector2D>(through: [[0, 0], [0, 0], [10, 0]])
+        let tangent = curve.derivativeView.tangent(at: 0)
+        #expect(tangent.unitVector.magnitude ≈ 1)
+        #expect(tangent ≈ Direction2D(x: 1, y: 0))
+    }
+
+    @Test func `ordinary interpolating curve tangents are unchanged`() {
+        let curve = InterpolatingCurve<Vector2D>(through: [[0, 0], [10, 0], [20, 0]])
+        #expect(curve.derivativeView.tangent(at: 1) ≈ Direction2D(x: 1, y: 0))
+    }
+
+    @Test func `a spline curve stalled by repeated control points still has a unit tangent`() {
+        // The first three control points coincide, so the curve is stationary across the whole first
+        // knot span and a finite difference there is exactly zero.
+        let curve = SplineCurve<Vector2D>(
+            degree: 2,
+            knots: [0, 0, 0, 1, 2, 2, 2],
+            controlPoints: [([0, 0], weight: 1), ([0, 0], weight: 1), ([0, 0], weight: 1), ([10, 0], weight: 1)]
+        )
+        for u in [0.0, 0.25, 0.5] {
+            let tangent = curve.tangent(at: u)
+            #expect(tangent.unitVector.magnitude ≈ 1, "at u = \(u)")
+            #expect(tangent ≈ Direction2D(x: 1, y: 0), "at u = \(u)")
+        }
+    }
+
+    @Test func `ordinary spline tangents are unchanged`() {
+        let curve = SplineCurve<Vector2D>(
+            degree: 2,
+            knots: [0, 0, 0, 1, 1, 1],
+            controlPoints: [([0, 0], weight: 1), ([10, 0], weight: 1), ([10, 10], weight: 1)]
+        )
+        #expect(curve.tangent(at: 0) ≈ Direction2D(x: 1, y: 0))
+        #expect(curve.tangent(at: 1) ≈ Direction2D(x: 0, y: 1))
+    }
+}

--- a/Tests/Tests/CurveDegenerateInputs.swift
+++ b/Tests/Tests/CurveDegenerateInputs.swift
@@ -125,9 +125,27 @@ struct CurveDegenerateInputTests {
         #expect(tangent ≈ Direction3D(x: 0, y: 0, z: 1))
     }
 
-    @Test func `a straight line collapsed to a point falls back to a unit tangent`() {
+    @Test func `an undefined direction is exactly the zero direction`() {
+        #expect(Direction3D.undefined.isUndefined)
+        #expect(Direction3D(Vector3D.zero).isUndefined)
+        #expect(Direction3D(Vector3D.zero) == .undefined)
+        #expect(Direction2D.undefined.isUndefined)
+
+        // A vector of any usable length normalizes to unit length, however small.
+        let small = Direction3D(Vector3D(1e-100, 0, 0))
+        #expect(small.isUndefined == false)
+        #expect(small.unitVector.magnitude ≈ 1)
+
+        // An ordinary direction is defined.
+        #expect(Direction3D(Vector3D(0, 0, 5)).isUndefined == false)
+    }
+
+    @Test func `a line collapsed to a point has no direction to report`() {
+        // Nothing here is a tangent: the curve never moves. This documents that the degenerate case is
+        // left as it has always been rather than being given an arbitrary direction that would be
+        // indistinguishable from a real one.
         let curve = BezierPath2D.Curve(controlPoints: [[3, 4], [3, 4]])
-        #expect(curve.tangent(at: 0.5).unitVector.magnitude ≈ 1)
+        #expect(curve.tangent(at: 0.5).isUndefined)
     }
 
     @Test func `a path end direction is unit length when the last curve has no end tension`() {

--- a/Tests/Tests/Sweep.swift
+++ b/Tests/Tests/Sweep.swift
@@ -28,9 +28,13 @@ struct SweepTests {
 
         let m = try await sweep.measurements
 
-        #expect(m.volume ≈ 11652.703)
-        #expect(m.surfaceArea ≈ 18070.729)
-        #expect(m.boundingBox ≈ .init(minimum: [0, -5.595, -3], maximum: [105.831, 100, 155.5]))
+        // Exactly one of this sweep's 1553 frames has no resolvable twist angle (the tangent is briefly
+        // antiparallel to the `.down` target where the path runs vertically), bracketed by frames at 0°
+        // and 90°. interpolateMissingAngles() used to hand it the preceding angle verbatim, leaving a
+        // 0° → 0° → 90° step; it now interpolates to 45°. These figures are that corrected frame.
+        #expect(m.volume ≈ 11653.029)
+        #expect(m.surfaceArea ≈ 18070.705)
+        #expect(m.boundingBox ≈ .init(minimum: [0, -5.60051, -3], maximum: [105.831, 100, 155.5]))
     }
 
     @Test func `star shape can be swept along 2D path`() async throws {


### PR DESCRIPTION
Three failures, all reachable from ordinary input. Two of them kill the process.

**`interpolateMissingAngles()` traps on an inverted range.** It built a `Range<Angle>` from the two frame angles bracketing a run of unresolved ones. Those come straight from `atan2` and land anywhere in (-180, 180] in whatever order the curve produces, and `normalizeAngles()`, which monotonizes them, only runs afterwards. So any sweep whose angle decreases across the run dies on `Range requires lowerBound <= upperBound`. A frame sequence of `170°, nil, -170°` is enough.

The same block has two more problems. It divides the arc by the count of missing frames rather than that count plus one, so the first missing frame duplicates the preceding angle and the last never reaches the following one: `[0°, nil, nil, nil, 40°]` came out `[0°, 0°, 13.3°, 26.7°, 40°]` instead of evenly spaced. And it interpolates raw angles, so a run crossing the 180 degree seam goes the long way round. It now takes plain lower and upper angles, steps along the shortest signed arc, and divides by `k + 1`.

That correction moves one frame of the 3D bezier sweep test. Of its 1553 frames exactly one has no resolvable twist angle, where the tangent goes briefly antiparallel to the `.down` target as the path runs vertically. It sits between frames at 0° and 90°, used to be handed 0° verbatim, and is now interpolated to 45°. Volume moves from 11652.703 to 11653.029, about 0.003%. I isolated this by stashing only that one file to confirm it was the sole cause, then dumped the frames for that exact path to find the single frame responsible. The expected measurements are updated with a comment recording why.

**`subpath(in:)` traps on a collapsed range.** It pulls `upperIndex` back below `lowerIndex` for a range collapsed onto a curve boundary, so `(1...0)` traps; a range collapsed anywhere else produces a single-control-point curve, which `points()` then reads out of bounds. Both are reachable from `BezierPath.points(in:segmentation:)`. `subpath` now returns a curveless path for a degenerate range, and `points()` handles a one-control-point curve explicitly. `curveIndexAndFraction` is left alone, since it is also `point(at:)`'s clamping lookup and changing its convention there would be a wider behavioural change than this needs.

**Vanishing tangents produce a zero unit vector.** `BezierCurve.tangent(at:)` normalized the first derivative unconditionally. A cubic whose first two control points coincide, which is an ordinary way to leave a point with no tension, has zero derivative there, and `Direction` accepts the zero vector as a unit direction without complaint. The result is a frame with no Z axis and a plane with no normal, with no NaN and no trap to show for it. It now falls back to the second derivative, which is what L'Hopital gives for the true tangent at that endpoint, and then to the chord. The sign flips at `fraction >= 1`, where the end can only be approached from inside. `SplineCurve.tangent` and `InterpolatingCurveDerivativeView.tangent` difference to exactly zero across a stationary segment and now widen the sampling window before falling back the same way. Non-degenerate tangents keep their original base step and first central difference, so they are computed exactly as before.

One more, found while testing that last one. `InterpolatingCurve.point(at:)` floored its centripetal times with `.leastNonzeroMagnitude` and then took the reciprocal, which overflows to infinity for a subnormal, so `0 × ∞` made every point on a segment NaN whenever two control points coincided. Floored with `.leastNormalMagnitude` instead, which is identical for every non-degenerate input.

`Direction.init(_:)` is deliberately left alone. Making it failable spreads through 8 initializers, 5 derived members and 49 construction sites, and would not close the hole anyway: `Direction` is `Codable` with a synthesized conformance, so decoding never runs it. Trapping is source-compatible but would turn today's silent corruption into crashes at the 17 sites that build a direction from a difference, cross product or bisector, all of which can legitimately be zero. Fixing the producer removes the reachable path; the initializer is worth its own change with that audit at its centre.

Both trapping cases are covered by tests that fail against the current code by killing the test process, so they were run individually to capture the traps.
