### PR TITLE
Subdivide Loft by surface deviation instead of by ring spacing

### DIFF
--- a/Sources/Cadova/Abstract Layer/Operations/Loft/Loft+PolygonGroupInterpolation.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/Loft/Loft+PolygonGroupInterpolation.swift
@@ -13,8 +13,32 @@ internal extension Loft {
         let segmentation = environment.scaledSegmentation
         var refinedGroups: [(polygons: SimplePolygonList, transforms: [Transform3D])] = []
 
+        // `frames` is ordered by distance, so the corner frames within it are too. Collecting their
+        // indices once turns "is there a corner inside this span?" into a binary search over a handful
+        // of entries. The subdivision below asks that question at every node of its recursion, and on
+        // a smooth path the answer is always no, which used to mean rescanning the whole frame array
+        // every time.
+        let cornerIndices = frames.indices.filter { frames[$0].miterStretch != nil }
+
         func transform(atDistance distance: Double) -> Transform3D {
             curve.exactFrame(atDistance: distance, in: frames, reference: reference, target: sweepTarget).transform
+        }
+
+        /// The index, within `cornerIndices`, of the first corner frame lying strictly between two
+        /// distances along the path, or `nil` if that stretch of path is smooth.
+        func firstCorner(in searchRange: Range<Int>, between start: Double, and end: Double) -> Int? {
+            var low = searchRange.lowerBound
+            var high = searchRange.upperBound
+            while low < high {
+                let middle = (low + high) / 2
+                if frames[cornerIndices[middle]].distance > start {
+                    high = middle
+                } else {
+                    low = middle + 1
+                }
+            }
+            guard low < searchRange.upperBound, frames[cornerIndices[low]].distance < end else { return nil }
+            return low
         }
 
         for polygons in polygonGroups {
@@ -56,9 +80,28 @@ internal extension Loft {
                             return (polygon, transform(atDistance: distance))
                         }
 
-                    case .adaptive(_, let minLength):
+                    case .adaptive(let minAngle, let minSize):
                         var results: [(polygon: SimplePolygon, transform: Transform3D)] = []
                         let sectionSpan = section1.distance - section0.distance
+                        let maximumDeviation = Segmentation.surfaceDeviation(minAngle: minAngle, minSize: minSize)
+                        // A backstop against a shaping function with a genuine discontinuity in it,
+                        // which bisection can never resolve. The deviation test bottoms out long
+                        // before this on anything continuous.
+                        let maximumSubdivisionDepth = 32
+
+                        func exactFrame(at fraction: Double) -> ParametricCurveFrame {
+                            let distance = section0.distance + sectionSpan * fraction
+                            return curve.exactFrame(atDistance: distance, in: frames, reference: reference, target: sweepTarget)
+                        }
+
+                        /// A ring on a smooth stretch of path, placed by the path's own frame there.
+                        func regularSample(at fraction: Double) -> RingSample {
+                            let distance = section0.distance + sectionSpan * fraction
+                            return RingSample(
+                                polygon: lower.blended(with: upper, t: function(fraction)),
+                                transform: transform(atDistance: distance)
+                            )
+                        }
 
                         // A genuine sharp corner in the path is an irreducible discontinuity in the
                         // path tangent: transforms on either side never converge to each other by
@@ -66,26 +109,18 @@ internal extension Loft {
                         // surrounding frames' orientation and miter stretch toward that frame. This
                         // keeps the loft surface continuous instead of creating a short, separate-looking
                         // patch around the corner.
-                        func regularSection(at fraction: Double) -> (polygon: SimplePolygon, transform: Transform3D) {
-                            let distance = section0.distance + sectionSpan * fraction
-                            return (
-                                lower.blended(with: upper, t: function(fraction)),
-                                transform(atDistance: distance)
-                            )
-                        }
-
-                        func exactFrame(at fraction: Double) -> ParametricCurveFrame {
-                            let distance = section0.distance + sectionSpan * fraction
-                            return curve.exactFrame(atDistance: distance, in: frames, reference: reference, target: sweepTarget)
-                        }
-
-                        func interpolatedSection(at fraction: Double, from start: ParametricCurveFrame, to end: ParametricCurveFrame, over range: Range<Double>) -> (polygon: SimplePolygon, transform: Transform3D) {
+                        func interpolatedSample(
+                            at fraction: Double,
+                            from start: ParametricCurveFrame,
+                            to end: ParametricCurveFrame,
+                            over range: Range<Double>
+                        ) -> RingSample {
                             let frame = exactFrame(at: fraction)
                             let span = range.upperBound - range.lowerBound
                             let interpolation = span > 1e-12 ? (fraction - range.lowerBound) / span : 0
-                            return (
-                                lower.blended(with: upper, t: function(fraction)),
-                                start.interpolated(
+                            return RingSample(
+                                polygon: lower.blended(with: upper, t: function(fraction)),
+                                transform: start.interpolated(
                                     to: end,
                                     factor: interpolation,
                                     distance: frame.distance,
@@ -95,93 +130,149 @@ internal extension Loft {
                             )
                         }
 
-                        func subdivideSmooth(
+                        /// Bisects a smooth span until the surface across it is flat enough to be left
+                        /// as a single band, emitting the lower bound of every span that survives.
+                        ///
+                        /// The test is a sagitta: build the interior rings both ways — the true
+                        /// interpolated ring, and where an unsubdivided band between the two end rings
+                        /// would put it — and keep splitting only while they disagree by more than the
+                        /// deviation budget. Linear shaping along a straight path makes the two agree
+                        /// exactly, which is why such a loft now stops at its two section rings.
+                        ///
+                        /// Three interior rings are checked, not just the midpoint. Shaping functions
+                        /// that are symmetric about (0.5, 0.5) — `.smoothstep`, `.sine`, `.easeInOut`,
+                        /// `.smootherstep` — pass exactly through the midpoint of their own chord, so a
+                        /// midpoint-only test measures no error for them and would flatten the entire
+                        /// S-curve into one band. The quarter points see the bulge, and they aren't
+                        /// extra work: each becomes the midpoint of one of the two halves.
+                        func subdivideSpan(
                             range: Range<Double>,
-                            interpolationRange: Range<Double>,
-                            start: ParametricCurveFrame,
-                            end: ParametricCurveFrame,
-                            depth: Int = 0,
-                            skipLowerBound: Bool = false
+                            start: RingSample,
+                            end: RingSample,
+                            middle: RingSample,
+                            depth: Int,
+                            skipLowerBound: Bool,
+                            sample: (Double) -> RingSample
+                        ) {
+                            let quarter = sample((range.lowerBound + range.mid) / 2)
+                            let threeQuarters = sample((range.mid + range.upperBound) / 2)
+                            let bandLength = start.separation(from: end)
+
+                            // Warp is a two-directional error, so it is only worth acting on while the
+                            // band is still longer than the rings' own edges. Below that the triangles
+                            // are already more elongated along the path than around the ring, the
+                            // surface error is dominated by the ring's own resolution, and splitting
+                            // again refines the finer of the two directions for nothing. This also
+                            // keeps the criterion from chasing a hand-built, deliberately coarse ring
+                            // to absurd depth.
+                            let warp = bandLength > start.maximumEdgeLength ? start.warp(across: end) : 0
+
+                            let deviation = max(
+                                quarter.deviation(fromChordBetween: start, and: end, at: 0.25),
+                                middle.deviation(fromChordBetween: start, and: end, at: 0.5),
+                                threeQuarters.deviation(fromChordBetween: start, and: end, at: 0.75),
+                                warp
+                            )
+
+                            // Bisection stops on three counts: the band is already accurate enough;
+                            // the two end rings are themselves closer together than the error being
+                            // controlled, so nothing between them can be resolved and splitting
+                            // further would only emit rings on top of each other; or the recursion
+                            // has gone absurdly deep, which only a discontinuous shaping function
+                            // can cause.
+                            if deviation > maximumDeviation,
+                               bandLength > maximumDeviation,
+                               depth < maximumSubdivisionDepth {
+                                subdivideSpan(
+                                    range: range.lowerBound..<range.mid,
+                                    start: start, end: middle, middle: quarter,
+                                    depth: depth + 1, skipLowerBound: skipLowerBound, sample: sample
+                                )
+                                subdivideSpan(
+                                    range: range.mid..<range.upperBound,
+                                    start: middle, end: end, middle: threeQuarters,
+                                    depth: depth + 1, skipLowerBound: false, sample: sample
+                                )
+                            } else if !skipLowerBound {
+                                results.append((start.polygon, start.transform))
+                            }
+                        }
+
+                        /// Splits the span at each sharp corner it contains and hands the smooth
+                        /// stretches between them to `subdivideSpan`. End rings are threaded through
+                        /// rather than recomputed: every ring is built exactly once.
+                        func subdivide(
+                            range: Range<Double>,
+                            cornerSearchRange: Range<Int>,
+                            start: RingSample,
+                            end: RingSample,
+                            skipLowerBound: Bool
                         ) {
                             let distanceStart = section0.distance + sectionSpan * range.lowerBound
                             let distanceEnd = section0.distance + sectionSpan * range.upperBound
-                            let startSection = interpolatedSection(at: range.lowerBound, from: start, to: end, over: interpolationRange)
-                            let endSection = interpolatedSection(at: range.upperBound, from: start, to: end, over: interpolationRange)
 
-                            if distanceEnd - distanceStart > minLength,
-                               depth < 32,
-                               startSection.polygon.needsSubdivision(next: endSection.polygon, transform0: startSection.transform, transform1: endSection.transform, minLength: minLength) {
-                                let tMid = range.mid
-                                subdivideSmooth(range: range.lowerBound..<tMid, interpolationRange: interpolationRange, start: start, end: end, depth: depth + 1, skipLowerBound: skipLowerBound)
-                                subdivideSmooth(range: tMid..<range.upperBound, interpolationRange: interpolationRange, start: start, end: end, depth: depth + 1)
-                            } else if !skipLowerBound {
-                                results.append(startSection)
-                            }
-                        }
-
-                        func subdivide(range: Range<Double>, frameSearchRange: Range<Int>, depth: Int = 0, skipLowerBound: Bool = false) {
-                            let distanceStart = section0.distance + sectionSpan * range.lowerBound
-                            let distanceEnd = section0.distance + sectionSpan * range.upperBound
-
-                            if let cornerIndex = frames[frameSearchRange].firstIndex(where: {
-                                $0.miterStretch != nil && $0.distance > distanceStart && $0.distance < distanceEnd
-                            }) {
-                                let corner = frames[cornerIndex]
-                                let cornerFraction = (corner.distance - section0.distance) / sectionSpan
-
-                                if cornerFraction > range.lowerBound + 1e-12 {
-                                    subdivideSmooth(
-                                        range: range.lowerBound..<cornerFraction,
-                                        interpolationRange: range.lowerBound..<cornerFraction,
-                                        start: exactFrame(at: range.lowerBound),
-                                        end: corner,
-                                        depth: depth + 1,
-                                        skipLowerBound: skipLowerBound
-                                    )
-                                }
-                                results.append((lower.blended(with: upper, t: function(cornerFraction)), corner.transform))
-                                if cornerFraction < range.upperBound - 1e-12 {
-                                    let remainingFrameSearchRange = (cornerIndex + 1)..<frameSearchRange.upperBound
-                                    if remainingFrameSearchRange.contains(where: {
-                                        frames[$0].miterStretch != nil && frames[$0].distance > corner.distance && frames[$0].distance < distanceEnd
-                                    }) {
-                                        subdivide(
-                                            range: cornerFraction..<range.upperBound,
-                                            frameSearchRange: remainingFrameSearchRange,
-                                            depth: depth + 1,
-                                            skipLowerBound: true
-                                        )
-                                    } else {
-                                        subdivideSmooth(
-                                            range: cornerFraction..<range.upperBound,
-                                            interpolationRange: cornerFraction..<range.upperBound,
-                                            start: corner,
-                                            end: exactFrame(at: range.upperBound),
-                                            depth: depth + 1,
-                                            skipLowerBound: true
-                                        )
-                                    }
-                                }
+                            guard let cornerSlot = firstCorner(
+                                in: cornerSearchRange, between: distanceStart, and: distanceEnd
+                            ) else {
+                                subdivideSpan(
+                                    range: range, start: start, end: end, middle: regularSample(at: range.mid),
+                                    depth: 0, skipLowerBound: skipLowerBound, sample: regularSample
+                                )
                                 return
                             }
 
-                            let transformStart = transform(atDistance: distanceStart)
-                            let transformEnd = transform(atDistance: distanceEnd)
-                            let pStart = lower.blended(with: upper, t: function(range.lowerBound))
-                            let pEnd = lower.blended(with: upper, t: function(range.upperBound))
+                            let corner = frames[cornerIndices[cornerSlot]]
+                            let cornerFraction = (corner.distance - section0.distance) / sectionSpan
+                            let cornerSample = RingSample(
+                                polygon: lower.blended(with: upper, t: function(cornerFraction)),
+                                transform: corner.transform
+                            )
 
-                            if distanceEnd - distanceStart > minLength,
-                               depth < 32,
-                               pStart.needsSubdivision(next: pEnd, transform0: transformStart, transform1: transformEnd, minLength: minLength) {
-                                let tMid = range.mid
-                                subdivide(range: range.lowerBound..<tMid, frameSearchRange: frameSearchRange, depth: depth + 1, skipLowerBound: skipLowerBound)
-                                subdivide(range: tMid..<range.upperBound, frameSearchRange: frameSearchRange, depth: depth + 1)
-                            } else if !skipLowerBound {
-                                results.append((pStart, transformStart))
+                            if cornerFraction > range.lowerBound + 1e-12 {
+                                let leadIn = range.lowerBound..<cornerFraction
+                                let startFrame = exactFrame(at: range.lowerBound)
+                                func leadInSample(_ fraction: Double) -> RingSample {
+                                    interpolatedSample(at: fraction, from: startFrame, to: corner, over: leadIn)
+                                }
+                                subdivideSpan(
+                                    range: leadIn, start: start, end: cornerSample,
+                                    middle: leadInSample(leadIn.mid),
+                                    depth: 0, skipLowerBound: skipLowerBound, sample: leadInSample
+                                )
+                            }
+
+                            results.append((cornerSample.polygon, cornerSample.transform))
+
+                            if cornerFraction < range.upperBound - 1e-12 {
+                                let remaining = (cornerSlot + 1)..<cornerSearchRange.upperBound
+                                if firstCorner(in: remaining, between: corner.distance, and: distanceEnd) != nil {
+                                    subdivide(
+                                        range: cornerFraction..<range.upperBound,
+                                        cornerSearchRange: remaining,
+                                        start: cornerSample, end: end, skipLowerBound: true
+                                    )
+                                } else {
+                                    let leadOut = cornerFraction..<range.upperBound
+                                    let endFrame = exactFrame(at: range.upperBound)
+                                    func leadOutSample(_ fraction: Double) -> RingSample {
+                                        interpolatedSample(at: fraction, from: corner, to: endFrame, over: leadOut)
+                                    }
+                                    subdivideSpan(
+                                        range: leadOut, start: cornerSample, end: end,
+                                        middle: leadOutSample(leadOut.mid),
+                                        depth: 0, skipLowerBound: true, sample: leadOutSample
+                                    )
+                                }
                             }
                         }
 
-                        subdivide(range: 0..<1, frameSearchRange: frames.indices, skipLowerBound: true)
+                        subdivide(
+                            range: 0..<1,
+                            cornerSearchRange: cornerIndices.indices,
+                            start: RingSample(polygon: lower.blended(with: upper, t: function(0)), transform: transform0),
+                            end: RingSample(polygon: lower.blended(with: upper, t: function(1)), transform: transform1),
+                            skipLowerBound: true
+                        )
                         interpolatedSections = results
                     }
                 }
@@ -199,6 +290,85 @@ internal extension Loft {
     }
 }
 
+/// A candidate cross-section ring: the blended 2D polygon, and the frame transform that places it in
+/// space. Its world-space vertices are computed once, when the ring is built, so that the subdivision
+/// test doesn't reapply two 4×4 transforms to every vertex at every level of the recursion, and so
+/// that a ring built as one span's interior sample can be reused as an end ring of the span's halves.
+fileprivate struct RingSample {
+    let polygon: SimplePolygon
+    let transform: Transform3D
+    let worldVertices: [Vector3D]
+    /// The longest edge of this ring, in world space — the resolution the mesh already has in the
+    /// around-the-ring direction, which bounds how much accuracy refining the other direction can buy.
+    let maximumEdgeLength: Double
+
+    init(polygon: SimplePolygon, transform: Transform3D) {
+        let worldVertices = polygon.vertices(transformedBy: transform)
+        self.polygon = polygon
+        self.transform = transform
+        self.worldVertices = worldVertices
+        self.maximumEdgeLength = worldVertices.cyclicPairs().reduce(0) { max($0, ($1.1 - $1.0).magnitude) }
+    }
+
+    /// How far this ring sits from where a single unsubdivided band between `start` and `end` would
+    /// put it, `fraction` of the way along that band, measured at its most displaced vertex.
+    ///
+    /// This is the sagitta of the loft's surface: exactly the fidelity that inserting a ring here
+    /// would buy, and zero whenever the band already describes the surface perfectly.
+    func deviation(fromChordBetween start: Self, and end: Self, at fraction: Double) -> Double {
+        let count = min(worldVertices.count, start.worldVertices.count, end.worldVertices.count)
+        var maximum = 0.0
+        for index in 0..<count {
+            let chordStart = start.worldVertices[index]
+            let chord = chordStart + (end.worldVertices[index] - chordStart) * fraction
+            maximum = max(maximum, (worldVertices[index] - chord).magnitude)
+        }
+        return maximum
+    }
+
+    /// The largest gap between the ruled surface a band to `other` stands for and the triangle strip
+    /// the mesh will actually build across it.
+    ///
+    /// The chord test above cannot see this. The mesh joins corresponding vertices of the two rings,
+    /// so every intermediate ring lies exactly on those rulings and reports no deviation at all — yet
+    /// each pair of adjacent rulings bounds a quad that is generally not planar, and gets split into
+    /// two triangles along a diagonal. At the quad's centre the true bilinear surface sits at
+    /// ¼(A + B + C + D) while the two triangles meet at the midpoint of either diagonal, and the part
+    /// of that offset normal to the quad is surface the mesh simply doesn't have. Only splitting the
+    /// band shortens it — halving the band halves the warp — which is what makes one long, strongly
+    /// sheared band genuinely worse than several short ones, however exactly ruled it is.
+    func warp(across other: Self) -> Double {
+        let count = min(worldVertices.count, other.worldVertices.count)
+        guard count > 1 else { return 0 }
+
+        var maximum = 0.0
+        for index in 0..<count {
+            let next = (index + 1) % count
+            let a = worldVertices[index]
+            let b = worldVertices[next]
+            let c = other.worldVertices[next]
+            let d = other.worldVertices[index]
+
+            let normal = (c - a) × (d - b)
+            let magnitude = normal.magnitude
+            guard magnitude > 1e-12 else { continue }
+            maximum = max(maximum, abs(((a + c - b - d) / 4) ⋅ (normal / magnitude)))
+        }
+        return maximum
+    }
+
+    /// How far apart two rings sit at their most separated vertex.
+    func separation(from other: Self) -> Double {
+        let count = min(worldVertices.count, other.worldVertices.count)
+        var maximum = 0.0
+        for index in 0..<count {
+            maximum = max(maximum, (worldVertices[index] - other.worldVertices[index]).magnitude)
+        }
+        return maximum
+    }
+}
+
+
 fileprivate extension Transform3D {
     // Compares only the rotational part of two transforms, ignoring translation. Two sections along a
     // path always sit at different positions, so comparing full transforms (translation included) would
@@ -210,13 +380,5 @@ fileprivate extension Transform3D {
         let dx = relative.apply(to: Vector3D(x: 1)) - origin - Vector3D(x: 1)
         let dy = relative.apply(to: Vector3D(y: 1)) - origin - Vector3D(y: 1)
         return dx.magnitude < 1e-9 && dy.magnitude < 1e-9
-    }
-}
-
-fileprivate extension SimplePolygon {
-    func needsSubdivision(next: SimplePolygon, transform0: Transform3D, transform1: Transform3D, minLength: Double) -> Bool {
-        (0..<count).contains {
-            (transform1.apply(to: Vector3D(next[$0], z: 0)) - transform0.apply(to: Vector3D(self[$0], z: 0))).magnitude > minLength
-        }
     }
 }

--- a/Sources/Cadova/Abstract Layer/Operations/Loft/Loft+PolygonGroupInterpolation.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/Loft/Loft+PolygonGroupInterpolation.swift
@@ -212,21 +212,28 @@ internal extension Loft {
                                 )
                             }
 
-                            // Warp is a two-directional error, so it is only worth acting on while the
-                            // band is still longer than the rings' own edges. Below that the triangles
-                            // are already more elongated along the path than around the ring, the
-                            // surface error is dominated by the ring's own resolution, and splitting
-                            // again refines the finer of the two directions for nothing. This also
-                            // keeps the criterion from chasing a hand-built, deliberately coarse ring
-                            // to absurd depth.
-                            let warp = bandLength > start.maximumEdgeLength ? start.warp(across: end) : 0
+                            // Warp is a two-directional error, so it stops being worth chasing once the
+                            // band is shorter than the rings' own edges. Below that the triangles are
+                            // already more elongated along the path than around the ring, the surface
+                            // error is dominated by the ring's own resolution, and splitting again
+                            // refines the finer of the two directions for nothing. This also keeps the
+                            // criterion from chasing a hand-built, deliberately coarse ring to absurd
+                            // depth. It fades the warp out across that crossover rather than dropping
+                            // it, so a short but strongly sheared band still reports the shear it has,
+                            // and it takes the longer of the two rings' edges so that one coarse end
+                            // ring cannot excuse the whole band on its own.
+                            let edgeLength = max(start.maximumEdgeLength, end.maximumEdgeLength)
+                            let warp = start.warp(across: end)
+                            let weightedWarp = bandLength >= edgeLength || edgeLength < 1e-12
+                                ? warp
+                                : warp * (bandLength / edgeLength)
 
                             let deviation = max(
                                 quarter.deviation(fromChordBetween: start, and: end, at: 0.25),
                                 middle.deviation(fromChordBetween: start, and: end, at: 0.5),
                                 threeQuarters.deviation(fromChordBetween: start, and: end, at: 0.75),
                                 probedDeviation,
-                                warp
+                                weightedWarp
                             )
 
                             // Bisection stops on three counts: the band is already accurate enough;

--- a/Sources/Cadova/Abstract Layer/Operations/Loft/Loft+PolygonGroupInterpolation.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/Loft/Loft+PolygonGroupInterpolation.swift
@@ -41,6 +41,30 @@ internal extension Loft {
             return low
         }
 
+        // One probe lattice per section pair, shared by every polygon group. Its samples depend only
+        // on the shaping function and the path, so building it inside the group loop would repeat
+        // identical work for every hole and island a section has. It is built on demand because a
+        // section pair whose shapes and orientation already match needs no subdivision at all, and so
+        // never asks for one.
+        var latticeCache: [Int: DeviationProbe.Lattice] = [:]
+        func deviationLattice(forSectionPair index: Int) -> DeviationProbe.Lattice {
+            if let cached = latticeCache[index] { return cached }
+            let start = sections[index - 1].distance
+            let span = sections[index].distance - start
+            let pathSampleCount = frames.reduce(0) {
+                $1.distance > start && $1.distance < start + span ? $0 + 1 : $0
+            }
+            let lattice = DeviationProbe.Lattice(
+                shaping: (sections[index].shapingFunction ?? .linear).function,
+                frames: frames,
+                startDistance: start,
+                span: span,
+                count: segmentation.deviationProbeCount(pathLength: span, pathSampleCount: pathSampleCount)
+            )
+            latticeCache[index] = lattice
+            return lattice
+        }
+
         for polygons in polygonGroups {
             var newPolygons: [SimplePolygon] = [polygons[0]]
             var newTransforms: [Transform3D] = [transform(atDistance: sections[0].distance)]
@@ -88,6 +112,10 @@ internal extension Loft {
                         // which bisection can never resolve. The deviation test bottoms out long
                         // before this on anything continuous.
                         let maximumSubdivisionDepth = 32
+
+                        let probe = DeviationProbe(
+                            lattice: deviationLattice(forSectionPair: i), lower: lower, upper: upper
+                        )
 
                         func exactFrame(at fraction: Double) -> ParametricCurveFrame {
                             let distance = section0.distance + sectionSpan * fraction
@@ -139,12 +167,21 @@ internal extension Loft {
                         /// deviation budget. Linear shaping along a straight path makes the two agree
                         /// exactly, which is why such a loft now stops at its two section rings.
                         ///
-                        /// Three interior rings are checked, not just the midpoint. Shaping functions
-                        /// that are symmetric about (0.5, 0.5) — `.smoothstep`, `.sine`, `.easeInOut`,
-                        /// `.smootherstep` — pass exactly through the midpoint of their own chord, so a
-                        /// midpoint-only test measures no error for them and would flatten the entire
-                        /// S-curve into one band. The quarter points see the bulge, and they aren't
-                        /// extra work: each becomes the midpoint of one of the two halves.
+                        /// Where the interior rings are measured matters as much as how. Three of them
+                        /// sit at fixed fractions: the midpoint, which is where the span will be split
+                        /// anyway, and the two quarter points, which cost nothing because each becomes
+                        /// the midpoint of one half. Those three are not enough on their own. Shaping
+                        /// functions symmetric about (0.5, 0.5), such as `.smoothstep`, `.sine`,
+                        /// `.easeInOut` and `.smootherstep`, pass exactly through the midpoint of their
+                        /// own chord, so a midpoint-only test reads no error for them at all, and any
+                        /// fixed set of fractions can be cancelled the same way by a function whose
+                        /// deviation vanishes at every one of them.
+                        ///
+                        /// A fourth ring closes that off. `DeviationProbe` searches a lattice far finer
+                        /// than anything that will be built, without building anything, and says where
+                        /// the surface is furthest from this band. The ring goes there. Nothing is
+                        /// decided from the probe's estimate; it only chooses the spot, and the error is
+                        /// then measured on a real ring exactly as the other three are.
                         func subdivideSpan(
                             range: Range<Double>,
                             start: RingSample,
@@ -154,9 +191,26 @@ internal extension Loft {
                             skipLowerBound: Bool,
                             sample: (Double) -> RingSample
                         ) {
-                            let quarter = sample((range.lowerBound + range.mid) / 2)
-                            let threeQuarters = sample((range.mid + range.upperBound) / 2)
+                            let spanWidth = range.upperBound - range.lowerBound
+                            let quarterFraction = (range.lowerBound + range.mid) / 2
+                            let threeQuartersFraction = (range.mid + range.upperBound) / 2
+                            let quarter = sample(quarterFraction)
+                            let threeQuarters = sample(threeQuartersFraction)
                             let bandLength = start.separation(from: end)
+
+                            // The one ring whose position is chosen by the shape rather than fixed in
+                            // advance. It is skipped when the probe finds nothing the three fixed
+                            // fractions do not already cover, which is the usual case on a function
+                            // that simply bulges one way.
+                            var probedDeviation = 0.0
+                            if spanWidth > 1e-12, let probedFraction = probe.worstFraction(
+                                in: range, tested: [quarterFraction, range.mid, threeQuartersFraction]
+                            ) {
+                                probedDeviation = sample(probedFraction).deviation(
+                                    fromChordBetween: start, and: end,
+                                    at: (probedFraction - range.lowerBound) / spanWidth
+                                )
+                            }
 
                             // Warp is a two-directional error, so it is only worth acting on while the
                             // band is still longer than the rings' own edges. Below that the triangles
@@ -171,6 +225,7 @@ internal extension Loft {
                                 quarter.deviation(fromChordBetween: start, and: end, at: 0.25),
                                 middle.deviation(fromChordBetween: start, and: end, at: 0.5),
                                 threeQuarters.deviation(fromChordBetween: start, and: end, at: 0.75),
+                                probedDeviation,
                                 warp
                             )
 
@@ -287,6 +342,171 @@ internal extension Loft {
         }
 
         return refinedGroups
+    }
+}
+
+/// A dense, precomputed picture of everything that can push a ring away from a straight band between
+/// two sections, used to choose where the subdivision test should look.
+///
+/// The test that decides whether a band is accurate enough can only measure rings it actually builds,
+/// and building a ring transforms every one of its vertices, so the test can only afford a few. Fixed
+/// sample positions are not a safe way to spend them. Whatever fractions are chosen, a shaping
+/// function whose deviation happens to vanish at all of them reads as perfectly flat, and the band is
+/// never split. Sampling at a quarter, a half and three quarters is cancelled exactly by
+/// `t + a·sin(4·2πt)` and by every other wave count that lines up with those three points, and adding
+/// a fifth fixed position only moves the blind spot to a different wave count. No fixed set of
+/// positions can be safe, because the function is free to have zeros wherever the set does.
+///
+/// So this stops guessing where to look and lets the shape say. Evaluating a shaping function is
+/// scalar arithmetic, thousands of times cheaper than building a ring, and the path has already been
+/// sampled into the frame array. This probe walks a lattice fine enough to resolve anything the
+/// segmentation could draw, estimates how far each lattice point's ring would sit from the band
+/// without building a single ring, and reports the worst point. The subdivision test then builds one
+/// real ring there and measures it exactly.
+///
+/// The estimate itself does not need to be accurate, and nothing is decided from it. It only has to
+/// point at roughly the right place, because the accuracy decision is still made by the exact
+/// measurement in `RingSample.deviation(fromChordBetween:and:at:)` on a ring that really was built.
+/// That leaves one limit, and it is a stated one rather than an accident of where three samples fell:
+/// a bump narrower than a lattice step can still hide, and a lattice step is finer than the shortest
+/// band this segmentation will ever emit, so a bump that narrow could not have been drawn either way.
+fileprivate struct DeviationProbe {
+    /// The lattice itself, separated from the polygons so that a section with holes or islands builds
+    /// it once rather than once per group. Its samples depend only on the shaping function and the
+    /// path, neither of which varies between the groups of one section pair.
+    struct Lattice {
+        struct Sample {
+            let fraction: Double
+            /// The blend parameter the shaping function asks for at this fraction.
+            let shaping: Double
+            /// Where the path's own frame sits here, read out of the frame array.
+            let point: Vector3D
+            /// That frame's roll about the path, in radians, or zero where the frames state none.
+            let angle: Double
+        }
+
+        let samples: [Sample]
+        /// One lattice step, in fraction units.
+        let step: Double
+
+        /// Walks the lattice and the frame array together in a single pass.
+        ///
+        /// Both are sorted and the lattice is uniform, so the frame bracketing each sample is found by
+        /// advancing one index rather than by searching from scratch every time. This is the whole
+        /// cost of the probe, and it needs to stay well under the cost of one ring.
+        ///
+        /// Reading the frames is deliberate, rather than calling `exactFrame`, which would evaluate
+        /// the curve and construct a frame at every lattice point. The frames are the path's own
+        /// sampling, so every feature the path has is already resolved among them, and the roll they
+        /// carry has been unwrapped and twist damped, which a freshly built frame would not know
+        /// about. Between two frames this treats the path as straight, which is exactly the
+        /// approximation the frame spacing was chosen to make safe.
+        init(
+            shaping: (Double) -> Double,
+            frames: [ParametricCurveFrame],
+            startDistance: Double,
+            span: Double,
+            count: Int
+        ) {
+            let count = max(count, 4)
+            self.step = 1 / Double(count)
+
+            var samples: [Sample] = []
+            samples.reserveCapacity(count + 1)
+            var frameIndex = 0
+            for index in 0...count {
+                let fraction = Double(index) / Double(count)
+                let distance = startDistance + span * fraction
+
+                while frameIndex + 2 < frames.count, frames[frameIndex + 1].distance <= distance {
+                    frameIndex += 1
+                }
+
+                var point = Vector3D.zero
+                var angle = 0.0
+                if frameIndex + 1 < frames.count {
+                    let lower = frames[frameIndex]
+                    let upper = frames[frameIndex + 1]
+                    let gap = upper.distance - lower.distance
+                    let within = gap > 1e-12 ? min(max((distance - lower.distance) / gap, 0), 1) : 0
+                    let lowerAngle = lower.angle?.radians ?? 0
+                    let upperAngle = upper.angle?.radians ?? lowerAngle
+                    point = lower.point + (upper.point - lower.point) * within
+                    angle = lowerAngle + (upperAngle - lowerAngle) * within
+                } else if let only = frames.first {
+                    point = only.point
+                    angle = only.angle?.radians ?? 0
+                }
+
+                samples.append(Sample(fraction: fraction, shaping: shaping(fraction), point: point, angle: angle))
+            }
+            self.samples = samples
+        }
+    }
+
+    private let lattice: Lattice
+    /// The furthest any single vertex travels as the blend runs from the lower section to the upper
+    /// one. Multiplying a blend error by this turns it into a distance.
+    private let morphScale: Double
+    /// The furthest any vertex sits from its own frame's origin. Multiplying a roll error in radians
+    /// by this turns it into a distance.
+    private let maximumRadius: Double
+
+    init(lattice: Lattice, lower: SimplePolygon, upper: SimplePolygon) {
+        self.lattice = lattice
+        // Vertices are blended one for one, so a blend error of d moves vertex i by d times its own
+        // travel, and the largest travel bounds them all.
+        self.morphScale = zip(lower.vertices, upper.vertices).reduce(0) { max($0, ($1.1 - $1.0).magnitude) }
+        self.maximumRadius = max(
+            lower.vertices.reduce(0) { max($0, $1.magnitude) },
+            upper.vertices.reduce(0) { max($0, $1.magnitude) }
+        )
+    }
+
+    /// The lattice point inside `range` whose ring is estimated to sit furthest from a straight band
+    /// across the range, or `nil` when there is nothing there worth building a ring for.
+    ///
+    /// `tested` lists the fractions the caller is going to build rings at anyway. A candidate within
+    /// one lattice step of one of those is skipped, since the ring the caller already builds is close
+    /// enough to measure the same error. That is what keeps this free on an ordinary bulging function
+    /// like `.circularEaseOut`, whose worst point is near the middle: its ring counts are unchanged.
+    /// A ring is spent only where the surface leaves the band somewhere the fixed fractions cannot
+    /// see.
+    func worstFraction(in range: Range<Double>, tested: [Double]) -> Double? {
+        let samples = lattice.samples
+        let step = lattice.step
+        // The lattice is uniform, so the bracketing indices come straight from the fractions.
+        let firstIndex = max(Int(ceil(range.lowerBound / step - 1e-9)), 0)
+        let lastIndex = min(Int(floor(range.upperBound / step + 1e-9)), samples.count - 1)
+        guard lastIndex - firstIndex >= 2 else { return nil }
+
+        let low = samples[firstIndex]
+        let high = samples[lastIndex]
+        let width = high.fraction - low.fraction
+        guard width > 1e-12 else { return nil }
+
+        var bestFraction: Double?
+        var bestEstimate = 0.0
+        for index in (firstIndex + 1)..<lastIndex {
+            let sample = samples[index]
+            if tested.contains(where: { abs(sample.fraction - $0) <= step }) { continue }
+
+            let fraction = (sample.fraction - low.fraction) / width
+            // A distance estimate, summed rather than combined properly. Each term is the largest
+            // displacement its own error can cause, so the sum overstates the true one, which is the
+            // right way round for a search: it can send the test somewhere it did not need to go, but
+            // it cannot talk it out of somewhere it did.
+            let blendError = abs(sample.shaping - (low.shaping + (high.shaping - low.shaping) * fraction))
+            let pointError = (sample.point - (low.point + (high.point - low.point) * fraction)).magnitude
+            let angleError = abs(sample.angle - (low.angle + (high.angle - low.angle) * fraction))
+            let estimate = blendError * morphScale + pointError + angleError * maximumRadius
+
+            if estimate > bestEstimate {
+                bestEstimate = estimate
+                bestFraction = sample.fraction
+            }
+        }
+        return bestEstimate > 0 ? bestFraction : nil
     }
 }
 

--- a/Sources/Cadova/Values/Curves/ParametricCurve/ParametricCurve+Frames.swift
+++ b/Sources/Cadova/Values/Curves/ParametricCurve/ParametricCurve+Frames.swift
@@ -40,16 +40,28 @@ internal extension ParametricCurve<Vector3D> {
         guard fraction < 1 - 1e-12 else { return upper }
 
         let t = lower.t + (upper.t - lower.t) * fraction
-        let sample = CurveSample(u: t, position: point(at: t), tangent: derivativeView.tangent(at: t), distance: distance)
+        // A curve that has collapsed at `t` reports an undefined (zero) tangent, and a frame built
+        // from one has no orientation at all. Both bracketing frames are already resolved, so fall
+        // back to the nearer of them, the way the `fraction` guards above do for the same reason.
+        let tangent = derivativeView.tangent(at: t)
+        guard !tangent.isUndefined else { return fraction < 0.5 ? lower : upper }
+
+        let sample = CurveSample(u: t, position: point(at: t), tangent: tangent, distance: distance)
         var frame = ParametricCurveFrame(
             sample: sample, reference: reference, target: target,
             previousSample: lower.frameForContinuingPastCorner(curve: self)
         )
-        // Reference/target can be momentarily degenerate (e.g. parallel to the tangent) exactly at this
-        // point even though neither bracketing sample was; `frames()` resolves this array-wide via
-        // interpolateMissingAngles(), which isn't available here, so fall back to interpolating between
-        // the two (already-resolved) bracketing angles instead of leaving it unset.
-        if frame.angle == nil, let lowerAngle = lower.angle, let upperAngle = upper.angle {
+        // The angle in `frames` is not a raw target alignment: `frames()` resolves degenerate samples
+        // array-wide (interpolateMissingAngles), unwraps the sequence so it never jumps by a turn
+        // (normalizeAngles), and then damps it to the environment's `maxTwistRate`. Constructing the
+        // frame above recomputes the angle from the target alone and so knows none of that, which
+        // makes this function disagree with the very array it interpolates — by well over a
+        // millimetre of vertex displacement wherever twist damping bit — and leaves any surface
+        // built from it with a step at every stored frame. Bracketing angles are continuous and
+        // already carry all of that resolution, so interpolate between them instead. (They also
+        // cover the case where the reference and target are momentarily degenerate here, e.g.
+        // parallel to the tangent, even though neither bracketing sample was.)
+        if let lowerAngle = lower.angle, let upperAngle = upper.angle {
             frame.angle = lowerAngle + (upperAngle - lowerAngle) * fraction
         }
         // miterStretch is a compensation for the corner frame's own oblique miter slice, not a property

--- a/Sources/Cadova/Values/Segmentation.swift
+++ b/Sources/Cadova/Values/Segmentation.swift
@@ -80,3 +80,27 @@ public enum Segmentation: Sendable, Hashable, Codable {
         }
     }
 }
+
+internal extension Segmentation {
+    /// The surface deviation this segmentation already accepts everywhere else, used as the budget
+    /// for deciding whether a loft needs another ring.
+    ///
+    /// Adaptive segmentation states two limits on a *chord*: `minSize` is the shortest chord worth
+    /// emitting, and `minAngle` the smallest turn worth resolving. Both bind at once on a circle of
+    /// radius `r = minSize / (2·sin(minAngle/2))`, and the sagitta there — the gap between the chord
+    /// and the arc it stands in for — is
+    ///
+    ///     s = r · (1 − cos(minAngle / 2)) = minSize · tan(minAngle / 4) / 2
+    ///
+    /// The radius cancels out, leaving the one error budget the two limits agree on. Spending that
+    /// same budget along the path makes a ring inserted between two sections worth exactly what a
+    /// vertex inserted around a ring is worth, so a loft's surface ends up neither coarser nor finer
+    /// than the circles it interpolates. With the defaults (2°, 0.15 mm) it comes to 0.65 µm.
+    ///
+    /// `\.tolerance` deliberately plays no part in this. That value is a fit clearance between mating
+    /// parts, orders of magnitude larger than a tessellation error; spending it here would let the
+    /// surface wander by the whole gap it exists to guarantee.
+    static func surfaceDeviation(minAngle: Angle, minSize: Double) -> Double {
+        minSize * tan(minAngle / 4) / 2
+    }
+}

--- a/Sources/Cadova/Values/Segmentation.swift
+++ b/Sources/Cadova/Values/Segmentation.swift
@@ -103,4 +103,28 @@ internal extension Segmentation {
     static func surfaceDeviation(minAngle: Angle, minSize: Double) -> Double {
         minSize * tan(minAngle / 4) / 2
     }
+
+    /// How many points to probe when looking for the place a loft's surface departs furthest from a
+    /// straight band, over a stretch of path `pathLength` long that the path itself sampled at
+    /// `pathSampleCount` points.
+    ///
+    /// This is a detection resolution, not an output resolution, so it is deliberately finer than
+    /// anything that gets built. The count comes from the two things that already bound how fine the
+    /// output can be. `segmentCount(length:)` is the most bands this segmentation would ever emit
+    /// over that length, and the path's own sample count is how finely the path was resolved, which
+    /// on a tight curve is the denser of the two. A feature narrower than the shorter of those two
+    /// spacings cannot be drawn, so probing finer than that can never change the mesh.
+    ///
+    /// The factor of four is headroom. Two samples per feature is the bare minimum to see a feature
+    /// at all, and four keeps detection comfortably away from being the limit, so the thing that
+    /// bounds accuracy stays the segmentation rather than the search.
+    ///
+    /// Probing is scalar arithmetic and costs nothing next to building a ring, so the only reason to
+    /// bound the count at all is to keep a very long path from paying for samples it cannot use. At
+    /// the cap the probe still matches `minSize` exactly on a path of about two and a half metres,
+    /// and only drops below four times oversampling beyond that.
+    func deviationProbeCount(pathLength: Double, pathSampleCount: Int) -> Int {
+        let byLength = segmentCount(length: pathLength)
+        return min(4 * max(byLength, pathSampleCount), 65536)
+    }
 }

--- a/Tests/Tests/Loft.swift
+++ b/Tests/Tests/Loft.swift
@@ -30,8 +30,16 @@ struct LoftTests {
         try await loft.writeVerificationModel(name: "loftThreeLayers")
         let m = try await loft.measurements
 
-        #expect(m.volume ≈ 7853.445)
-        #expect(m.surfaceArea ≈ 3791.824)
+        // Adaptive subdivision places rings by how far the surface would stray without them, so the
+        // exact triangulation — and with it the last digits of volume and area — depends on where
+        // those rings land. Building this same loft under fixed segmentation, which doesn't go
+        // through the adaptive criterion at all, spans 7850.1…7862.0 in volume and 3791.4…3793.9 in
+        // area from 64 to 1024 segments, so the value below is inside that bracket rather than at
+        // its edge. It is bit-identical over three separate processes, so it is pinned at the same
+        // tolerances as the two lofts below rather than loosely: a tolerance wide enough to admit
+        // the value this test carried before the change would not be pinning the change at all.
+        #expect(m.volume.equals(7853.271, within: 5e-2))
+        #expect(m.surfaceArea.equals(3792.011, within: 1e-2))
         #expect(m.boundingBox ≈ .init(minimum: [-12.5, -12.5, 0], maximum: [12.5, 12.5, 35]))
     }
 
@@ -54,9 +62,12 @@ struct LoftTests {
         try await loft.writeVerificationModel(name: "loftLayerSpecificShaping")
         let m = try await loft.measurements
 
-        // Manifold simplification produces slightly different floating-point results across platforms.
-        #expect(m.volume.equals(3863.623, within: 3e-2))
-        #expect(m.surfaceArea.equals(1236.890, within: 2e-3))
+        // Manifold simplification produces slightly different floating-point results across platforms,
+        // and adaptive subdivision decides where the rings go, so both are pinned loosely. Fixed
+        // segmentation from 128 to 1024 segments puts this shape at 3864.0…3864.7 in volume and
+        // 1236.9…1237.2 in area.
+        #expect(m.volume.equals(3864.48, within: 5e-2))
+        #expect(m.surfaceArea.equals(1237.073, within: 1e-2))
         #expect(m.boundingBox?.equals(.init(minimum: [-10, -10, 0], maximum: [10, 10, 20]), within: 1e-2) == true)
     }
 
@@ -79,9 +90,12 @@ struct LoftTests {
         try await loft.writeVerificationModel(name: "loftLayerSpecificShapingWithDefault")
         let m = try await loft.measurements
 
-        // Manifold simplification produces slightly different floating-point results across platforms.
-        #expect(m.volume.equals(2732.312, within: 5e-2))
-        #expect(m.surfaceArea.equals(1117.823, within: 1e-2))
+        // Manifold simplification produces slightly different floating-point results across platforms,
+        // and adaptive subdivision decides where the rings go, so both are pinned loosely. Fixed
+        // segmentation from 128 to 1024 segments puts this shape at 2732.4…2733.4 in volume and
+        // 1117.8…1118.4 in area.
+        #expect(m.volume.equals(2732.606, within: 5e-2))
+        #expect(m.surfaceArea.equals(1117.979, within: 1e-2))
         #expect(m.boundingBox?.equals(.init(minimum: [-10, -10, 0], maximum: [10, 10, 20]), within: 1e-2) == true)
     }
 

--- a/Tests/Tests/LoftSubdivision.swift
+++ b/Tests/Tests/LoftSubdivision.swift
@@ -1,0 +1,354 @@
+import Foundation
+import Testing
+@testable import Cadova
+
+/// Covers how densely `Loft` samples the surface between two sections.
+///
+/// The criterion has to be an *accuracy* test, not a *spacing* test: it must insert a ring only when
+/// leaving it out would move the surface, and it must insert one whenever leaving it out would. The
+/// first half of this suite drives `interpolatePolygonGroups` directly and counts the rings it asks
+/// for, once per branch of the criterion. The second half meshes the same shapes at the default
+/// segmentation and compares them against a deliberately over-refined reference, so a criterion that
+/// bought its ring count by losing fidelity fails here rather than passing quietly.
+struct LoftSubdivisionTests {
+    // A segmentation fine enough that its own error is far below what we're measuring, used to build
+    // the reference each fixed-resolution loft is compared against. Both `minAngle` and `minSize` are
+    // tightened, since the loft's ring resolution comes from `minSize` and its along-path resolution
+    // from both.
+    static let referenceSegmentation = Segmentation.adaptive(minAngle: 0.5°, minSize: 0.05)
+
+    static func polygonCircle(radius: Double, count: Int) -> SimplePolygon {
+        SimplePolygon((0..<count).map {
+            let angle = Double($0) / Double(count) * 360°
+            return Vector2D(cos(angle) * radius, sin(angle) * radius)
+        })
+    }
+
+    /// Runs the subdivision recursion on its own and returns the rings it produced, so a test can
+    /// count them without paying for a mesh.
+    static func rings(
+        from lower: SimplePolygon,
+        to upper: SimplePolygon,
+        along path: BezierPath3D,
+        distance: Double,
+        interpolation: ShapingFunction = .linear,
+        pointing reference: Direction2D = .negativeY,
+        toward target: ReferenceTarget = .direction(.negativeY),
+        environment: EnvironmentValues = .defaultEnvironment
+    ) -> (polygons: SimplePolygonList, transforms: [Transform3D]) {
+        let frames = path.frames(
+            environment: environment,
+            target: target,
+            targetReference: reference,
+            perpendicularBounds: .init(minimum: [-50, -50], maximum: [50, 50]),
+            miteringCorners: true
+        )
+        let sections = [
+            Loft.ResamplingSection(distance: 0, transition: .interpolated(.linear), tree: .empty),
+            Loft.ResamplingSection(distance: distance, transition: .interpolated(interpolation), tree: .empty),
+        ]
+        return Loft.interpolatePolygonGroups(
+            for: [SimplePolygonList([lower, upper])],
+            sections: sections,
+            frames: frames,
+            curve: path,
+            reference: reference,
+            target: target,
+            environment: environment
+        )[0]
+    }
+
+    static let verticalPath = BezierPath3D(linesBetween: [[0, 0, 0], [0, 0, 100]])
+
+    // MARK: - How many rings the criterion asks for
+
+    @Test func `linear shaping along a straight path needs no intermediate rings`() throws {
+        // With `.linear` shaping and an unchanging frame, the ring at any t is exactly
+        // lerp(lower, upper, t): every intermediate ring lands on the ruled surface the two bracketing
+        // rings already span, so every one of them is pure cost. The criterion must notice that and
+        // emit the two section rings and nothing else.
+        let result = Self.rings(
+            from: Self.polygonCircle(radius: 10, count: 256),
+            to: Self.polygonCircle(radius: 20, count: 256),
+            along: Self.verticalPath,
+            distance: 100
+        )
+        #expect(result.transforms.count == 2)
+    }
+
+    @Test func `a nonlinear shaping function is still subdivided`() throws {
+        // `.circularEaseOut` bulges away from the straight blend, so the surface genuinely curves
+        // between the two sections and rings have to be inserted to follow it.
+        let result = Self.rings(
+            from: Self.polygonCircle(radius: 10, count: 256),
+            to: Self.polygonCircle(radius: 20, count: 256),
+            along: Self.verticalPath,
+            distance: 100,
+            interpolation: .circularEaseOut
+        )
+        // Measured at 166 rings. The upper bound matters as much as the lower one:
+        // without it, an implementation that recursed to `maximumSubdivisionDepth` on every span
+        // would pass, and spending rings is the very thing this criterion exists to stop.
+        #expect((20..<400).contains(result.transforms.count))
+    }
+
+    @Test func `a shaping function that is symmetric about its own midpoint is still subdivided`() throws {
+        // `.smoothstep` (like `.sine`, `.easeInOut` and `.smootherstep`) passes exactly through the
+        // midpoint of its own chord: f(0.5) == 0.5. A deviation test that only ever samples the
+        // midpoint therefore measures zero error for it and collapses the whole S-curve into one
+        // straight band. The criterion has to look somewhere other than the midpoint too.
+        let result = Self.rings(
+            from: Self.polygonCircle(radius: 10, count: 256),
+            to: Self.polygonCircle(radius: 20, count: 256),
+            along: Self.verticalPath,
+            distance: 100,
+            interpolation: .smoothstep
+        )
+        // Measured at 105 rings. The upper bound matters as much as the lower one:
+        // without it, an implementation that recursed to `maximumSubdivisionDepth` on every span
+        // would pass, and spending rings is the very thing this criterion exists to stop.
+        #expect((20..<300).contains(result.transforms.count))
+    }
+
+    @Test func `a twisting path is still subdivided`() throws {
+        // Identical rings, straight path — but a skew target line rotates the frame as the loft rises,
+        // so a straight band between the end rings would cut across the twist.
+        let skewLine = D3.Line(point: [5, 0, 0], direction: Direction3D(x: 1, y: 1, z: 1))
+        let square = SimplePolygon([[-5, -2], [5, -2], [5, 2], [-5, 2]]).resampled(count: 64)
+        let result = Self.rings(
+            from: square,
+            to: square,
+            along: Self.verticalPath,
+            distance: 100,
+            toward: .line(skewLine)
+        )
+        // Measured at 78 rings. The upper bound matters as much as the lower one:
+        // without it, an implementation that recursed to `maximumSubdivisionDepth` on every span
+        // would pass, and spending rings is the very thing this criterion exists to stop.
+        #expect((20..<200).contains(result.transforms.count))
+    }
+
+    @Test func `a curving path is still subdivided`() throws {
+        let path = BezierPath3D(from: [0, 0, 0]) {
+            curve(controlX: 0, controlY: 0, controlZ: 30, endX: 30, endY: 0, endZ: 30)
+        }
+        let circle = Self.polygonCircle(radius: 6, count: 128)
+        let result = Self.rings(from: circle, to: circle, along: path, distance: 40)
+        // Measured at 192 rings. The upper bound matters as much as the lower one:
+        // without it, an implementation that recursed to `maximumSubdivisionDepth` on every span
+        // would pass, and spending rings is the very thing this criterion exists to stop.
+        #expect((20..<500).contains(result.transforms.count))
+    }
+
+    @Test func `the ring count for a straight linear loft does not grow with its length`() throws {
+        // A spacing criterion scales the ring count with the loft's length; an accuracy criterion
+        // doesn't, because a longer ruled surface is no less exactly ruled.
+        let short = Self.rings(
+            from: Self.polygonCircle(radius: 10, count: 256),
+            to: Self.polygonCircle(radius: 20, count: 256),
+            along: BezierPath3D(linesBetween: [[0, 0, 0], [0, 0, 10]]),
+            distance: 10
+        )
+        let long = Self.rings(
+            from: Self.polygonCircle(radius: 10, count: 256),
+            to: Self.polygonCircle(radius: 20, count: 256),
+            along: BezierPath3D(linesBetween: [[0, 0, 0], [0, 0, 1000]]),
+            distance: 1000
+        )
+        #expect(short.transforms.count == long.transforms.count)
+    }
+
+    @Test func `rings are never emitted on top of each other`() throws {
+        // Subdivision no longer stops at a fixed path spacing, so the recursion has to bottom out on
+        // its own before it starts emitting duplicate rings, which would make degenerate triangles.
+        let result = Self.rings(
+            from: Self.polygonCircle(radius: 3, count: 128),
+            to: Self.polygonCircle(radius: 12, count: 128),
+            along: Self.verticalPath,
+            distance: 100,
+            interpolation: .circularEaseOut
+        )
+        for (previous, next) in result.transforms.map(\.offset).paired() {
+            #expect(previous.distance(to: next) > 1e-6)
+        }
+    }
+
+    // MARK: - Fidelity against an over-refined reference
+
+    /// Builds the same loft twice — once at the default segmentation, once at a much finer one — and
+    /// checks that the coarser one still describes the same solid.
+    static func expectMatchesFineReference(
+        _ geometry: any Geometry3D,
+        volumeTolerance: Double,
+        areaTolerance: Double,
+        boundsTolerance: Double = 1e-2,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) async throws {
+        let actual = try await geometry.measurements
+        let reference = try await geometry.withSegmentation(referenceSegmentation).measurements
+
+        let volumeError = abs(actual.volume - reference.volume) / reference.volume
+        let areaError = abs(actual.surfaceArea - reference.surfaceArea) / reference.surfaceArea
+        #expect(volumeError < volumeTolerance, "relative volume error \(volumeError)", sourceLocation: sourceLocation)
+        #expect(areaError < areaTolerance, "relative surface area error \(areaError)", sourceLocation: sourceLocation)
+
+        let actualBox = try #require(actual.boundingBox, sourceLocation: sourceLocation)
+        let referenceBox = try #require(reference.boundingBox, sourceLocation: sourceLocation)
+        #expect(actualBox.equals(referenceBox, within: boundsTolerance), sourceLocation: sourceLocation)
+    }
+
+    @Test func `a straight linear cone matches its analytic volume and a fine reference`() async throws {
+        let bottomRadius = 10.0
+        let topRadius = 20.0
+        let height = 100.0
+        let loft = Loft {
+            Section(at: 0) { Circle(radius: bottomRadius) }
+            Section(at: height) { Circle(radius: topRadius) }
+        }
+
+        let m = try await loft.measurements
+        // A frustum's exact volume. The loft's rings are inscribed polygons rather than true circles,
+        // so the mesh sits very slightly inside the analytic solid.
+        let analyticVolume = .pi * height
+            * (bottomRadius * bottomRadius + bottomRadius * topRadius + topRadius * topRadius) / 3
+        #expect(abs(m.volume - analyticVolume) / analyticVolume < 1e-3)
+
+        try await Self.expectMatchesFineReference(loft, volumeTolerance: 1e-3, areaTolerance: 1e-3)
+    }
+
+    @Test func `a straight linear cone is no coarser than the equivalent cylinder`() async throws {
+        let loft = Loft {
+            Section(at: 0) { Circle(radius: 10) }
+            Section(at: 100) { Circle(radius: 20) }
+        }
+        let m = try await loft.measurements
+
+        // The exact solid, built by the primitive that doesn't have to interpolate anything. Both come
+        // out at 716 triangles, and both did before this change too, because `.simplified()` already
+        // discarded the excess: what the old criterion wasted was time, not output. So this test says
+        // nothing about cost, which the ring counts above pin instead. What it does say is that the
+        // new criterion has not started emitting a solid the primitive would call over-tessellated.
+        let cylinder = Cylinder(bottomRadius: 10, topRadius: 20, height: 100)
+        let cylinderTriangles = try await cylinder.measurements.triangleCount
+        #expect(m.triangleCount < cylinderTriangles * 2)
+    }
+
+    @Test func `a nonlinear shaping function keeps its shape at the default segmentation`() async throws {
+        try await Self.expectMatchesFineReference(
+            Loft {
+                Section(at: 0) { Circle(diameter: 5) }
+                Section(at: 5) { Circle(diameter: 12) }
+                Section(at: 15, interpolation: .circularEaseOut) { Circle(diameter: 20) }
+                Section(at: 20) { Circle(diameter: 10) }
+            },
+            volumeTolerance: 2e-3,
+            areaTolerance: 2e-3
+        )
+    }
+
+    @Test func `a symmetric shaping function keeps its shape at the default segmentation`() async throws {
+        try await Self.expectMatchesFineReference(
+            Loft(interpolation: .smoothstep) {
+                Section(at: 0) { Circle(diameter: 6) }
+                Section(at: 20) { Circle(diameter: 20) }
+            },
+            volumeTolerance: 2e-3,
+            areaTolerance: 2e-3
+        )
+    }
+
+    @Test func `a curving path keeps its shape at the default segmentation`() async throws {
+        let path = BezierPath3D(from: [0, 0, 0]) {
+            curve(controlX: 0, controlY: 0, controlZ: 30, endX: 30, endY: 0, endZ: 30)
+        }
+        try await Self.expectMatchesFineReference(
+            Loft(along: path, pointing: .negativeY, toward: .direction(.negativeZ)) {
+                Section(at: 0) { Circle(diameter: 12) }
+                Section(at: 40) { Circle(diameter: 12) }
+            },
+            volumeTolerance: 3e-3,
+            areaTolerance: 3e-3,
+            boundsTolerance: 0.1
+        )
+    }
+
+    @Test func `a twisting path keeps its shape at the default segmentation`() async throws {
+        let skewLine = D3.Line(point: [5, 0, 0], direction: Direction3D(x: 1, y: 1, z: 1))
+        let verticalPath = BezierPath3D(linesBetween: [[0, 0, 0], [0, 0, 40]])
+        let loft = Loft(along: verticalPath, pointing: .negativeY, toward: .line(skewLine)) {
+            Section(at: 0) { Rectangle(x: 10, y: 4).aligned(at: .center) }
+            Section(at: 40) { Rectangle(x: 10, y: 4).aligned(at: .center) }
+        }
+
+        // A twisted prism of constant cross-section keeps its untwisted volume when the twist is
+        // followed rather than cut across.
+        let m = try await loft.measurements
+        #expect(m.volume.equals(1600, within: 1))
+
+        try await Self.expectMatchesFineReference(loft, volumeTolerance: 2e-3, areaTolerance: 3e-3, boundsTolerance: 0.1)
+    }
+
+    @Test func `sections with holes and differing vertex counts keep their shape`() async throws {
+        try await Self.expectMatchesFineReference(
+            Loft {
+                Section(at: 0) {
+                    Circle(diameter: 20)
+                        .subtracting { Circle(diameter: 12) }
+                }
+                Section(at: 30) {
+                    Rectangle(x: 25, y: 6)
+                        .aligned(at: .center)
+                        .repeated(in: 0°..<180°, count: 2)
+                        .subtracting { RegularPolygon(sideCount: 8, circumradius: 2) }
+                }
+                Section(at: 35) {
+                    Circle(diameter: 12)
+                        .subtracting { Circle(diameter: 10) }
+                }
+            },
+            volumeTolerance: 5e-3,
+            areaTolerance: 5e-3,
+            boundsTolerance: 0.1
+        )
+    }
+
+    @Test func `an overhangSafe loft along a path keeps its shape`() async throws {
+        let path = BezierPath3D(linesBetween: [[0, 0, 0], [40, 0, 0]])
+        try await Self.expectMatchesFineReference(
+            Loft(along: path, pointing: .negativeY, toward: .direction(.negativeZ)) {
+                Section(at: 0) { Circle(radius: 6).overhangSafe(.teardrop) }
+                Section(at: 40) { Circle(radius: 6).overhangSafe(.teardrop) }
+            },
+            volumeTolerance: 2e-3,
+            areaTolerance: 2e-3,
+            boundsTolerance: 0.2
+        )
+    }
+
+    @Test func `a convex hull transition keeps its shape`() async throws {
+        try await Self.expectMatchesFineReference(
+            Loft {
+                Section(at: 0) { Circle(diameter: 10) }
+                Section(at: 10) { Circle(diameter: 20) }
+                Section(at: 20, interpolation: .convexHull) { Rectangle([8, 8]).aligned(at: .center) }
+                Section(at: 30) { Rectangle([15, 15]).aligned(at: .center) }
+            },
+            volumeTolerance: 3e-3,
+            areaTolerance: 3e-3,
+            boundsTolerance: 0.1
+        )
+    }
+
+    @Test func `a mitered sharp corner keeps its shape`() async throws {
+        let path = BezierPath3D(linesBetween: [[0, 0, 0], [0, 0, 40], [40, 0, 40]])
+        try await Self.expectMatchesFineReference(
+            Loft(along: path, pointing: .negativeY, toward: .direction(.negativeZ)) {
+                Section(at: 0) { Circle(diameter: 16) }
+                Section(at: 80) { Circle(diameter: 16) }
+            },
+            volumeTolerance: 5e-3,
+            areaTolerance: 5e-3,
+            boundsTolerance: 0.2
+        )
+    }
+}

--- a/Tests/Tests/LoftSubdivision.swift
+++ b/Tests/Tests/LoftSubdivision.swift
@@ -60,6 +60,29 @@ struct LoftSubdivisionTests {
 
     static let verticalPath = BezierPath3D(linesBetween: [[0, 0, 0], [0, 0, 100]])
 
+    /// A shaping function that rises overall but ripples on the way, so the surface between two
+    /// sections gains `waves` bulges instead of running straight.
+    ///
+    /// This is the family that catches a criterion which samples at fixed fractions. A whole number
+    /// of waves puts a zero crossing on every dyadic fraction at once, so the deviation from the
+    /// chord vanishes at a quarter, a half and three quarters together, and a test that only looks
+    /// there reads the whole thing as flat.
+    static func ripple(waves: Double, phase: Double = 0, amplitude: Double = 0.15) -> ShapingFunction {
+        .custom(name: "ripple", parameters: waves, phase, amplitude) { t in
+            t + amplitude * sin((waves * t + phase) * 2 * .pi)
+        }
+    }
+
+    static func rippleRings(waves: Double, phase: Double = 0) -> Int {
+        rings(
+            from: polygonCircle(radius: 25, count: 128),
+            to: polygonCircle(radius: 8, count: 128),
+            along: verticalPath,
+            distance: 100,
+            interpolation: ripple(waves: waves, phase: phase)
+        ).transforms.count
+    }
+
     // MARK: - How many rings the criterion asks for
 
     @Test func `linear shaping along a straight path needs no intermediate rings`() throws {
@@ -108,6 +131,67 @@ struct LoftSubdivisionTests {
         // without it, an implementation that recursed to `maximumSubdivisionDepth` on every span
         // would pass, and spending rings is the very thing this criterion exists to stop.
         #expect((20..<300).contains(result.transforms.count))
+    }
+
+    @Test func `a rippling shaping function is subdivided at every wave count`() throws {
+        // The criterion may not measure the surface at fractions fixed in advance. A whole number of
+        // waves lands a zero of the chord deviation on all of a quarter, a half and three quarters at
+        // once, so a test that samples only there reports no error and collapses the ripples into a
+        // plain cone. Every one of these wave counts did exactly that before the probe was added:
+        // 1 and 3 were subdivided, while 2, 4, 8, 16, 20 and 32 came out at two rings.
+        //
+        // The bounds are per wave, since a ripple genuinely needs rings in proportion to how many
+        // bulges it has. The lower one has teeth against the collapse; the upper one against an
+        // implementation that recurses to `maximumSubdivisionDepth` and calls it accuracy.
+        for waves in [1.0, 2, 3, 4, 8, 16, 20, 32] {
+            let count = Self.rippleRings(waves: waves)
+            #expect(
+                (Int(20 * waves)..<Int(400 * waves)).contains(count),
+                "\(waves) waves produced \(count) rings"
+            )
+        }
+    }
+
+    @Test func `the ring count for a rippling shaping function grows with the wave count`() throws {
+        // Subdividing every ripple is not enough on its own: an implementation could pass the test
+        // above by splitting blindly. Following the shape means paying for the bulges that are
+        // actually there, so twice the waves has to cost meaningfully more than half as many.
+        let two = Self.rippleRings(waves: 2)
+        let four = Self.rippleRings(waves: 4)
+        let eight = Self.rippleRings(waves: 8)
+        #expect(four > two)
+        #expect(eight > four)
+    }
+
+    @Test func `a rippling shaping function is subdivided off the dyadic fractions too`() throws {
+        // Nothing about the fix may depend on the waves lining up with the sample fractions. A wave
+        // count just off a whole number, and a whole one shifted in phase, both have to come out in
+        // the same range as the aligned counts above, not merely be caught by luck.
+        for waves in [2.001, 3.5, 4.25] {
+            let count = Self.rippleRings(waves: waves)
+            #expect((Int(20 * waves)..<Int(400 * waves)).contains(count), "\(waves) waves gave \(count) rings")
+        }
+        for phase in [0.125, 0.25, 0.5] {
+            let count = Self.rippleRings(waves: 4, phase: phase)
+            #expect((80..<1600).contains(count), "phase \(phase) gave \(count) rings")
+        }
+    }
+
+    @Test func `a shaping function whose waves speed up along the loft is subdivided`() throws {
+        // A chirp has no single wave count to line up with anything, and its bulges are wide at one
+        // end and narrow at the other. The criterion has to keep finding them as they tighten, which
+        // a search over the shape does and a fixed set of fractions cannot.
+        let chirp = ShapingFunction.custom(name: "chirp", parameters: 0) { t in
+            t + 0.1 * sin(2 * .pi * (2 * t + 6 * t * t))
+        }
+        let count = Self.rings(
+            from: Self.polygonCircle(radius: 25, count: 128),
+            to: Self.polygonCircle(radius: 8, count: 128),
+            along: Self.verticalPath,
+            distance: 100,
+            interpolation: chirp
+        ).transforms.count
+        #expect((200..<6000).contains(count), "chirp gave \(count) rings")
     }
 
     @Test func `a twisting path is still subdivided`() throws {
@@ -337,6 +421,43 @@ struct LoftSubdivisionTests {
             areaTolerance: 3e-3,
             boundsTolerance: 0.1
         )
+    }
+
+    @Test func `a rippling shaping function keeps its bulges at the default segmentation`() async throws {
+        // The report this test comes from: a four wave ripple between a wide and a narrow circle came
+        // out as a plain truncated cone, with volume and surface area equal to the same loft shaped
+        // `.linear`. So the check is against `.linear` as well as against a fine reference. Matching
+        // the fine reference alone would not catch it, because a mesh can agree with an over-refined
+        // version of the wrong shape.
+        let sections = { (interpolation: ShapingFunction) in
+            Loft(interpolation: interpolation) {
+                Section(at: 0) { Circle(radius: 25) }
+                Section(at: 100) { Circle(radius: 8) }
+            }
+        }
+        let rippled = sections(Self.ripple(waves: 4))
+        let straight = sections(.linear)
+
+        let rippledMeasurements = try await rippled.measurements
+        let straightMeasurements = try await straight.measurements
+
+        // Surface area is the figure that separates the two, at 13640 against 12678. Volume is not,
+        // and deliberately is not asserted on: this ripple is symmetric in the blend parameter, so it
+        // removes almost exactly as much material as it adds and comes out within 0.06% of the cone
+        // either way. That is a property of the shape, not evidence about the mesh, and a volume
+        // check here would be a check that passes for the wrong reason.
+        let areaRatio = rippledMeasurements.surfaceArea / straightMeasurements.surfaceArea
+        #expect(areaRatio > 1.05, "rippled surface area was \(areaRatio) times the cone's")
+
+        // The cone simplifies to 716 triangles and the ripples cannot: measured at 173698 against 716.
+        // This is the figure from the report, where the collapsed version came out at 716 as well.
+        #expect(
+            rippledMeasurements.triangleCount > straightMeasurements.triangleCount * 20,
+            "rippled mesh had \(rippledMeasurements.triangleCount) triangles against the cone's \(straightMeasurements.triangleCount)"
+        )
+
+        // Measured at 1.1e-4 and 1.4e-4, so this is pinned close rather than merely loosely bracketed.
+        try await Self.expectMatchesFineReference(rippled, volumeTolerance: 1e-3, areaTolerance: 1e-3)
     }
 
     @Test func `a mitered sharp corner keeps its shape`() async throws {

--- a/Tests/Tests/LoftSubdivision.swift
+++ b/Tests/Tests/LoftSubdivision.swift
@@ -206,7 +206,9 @@ struct LoftSubdivisionTests {
             distance: 100,
             toward: .line(skewLine)
         )
-        // Measured at 78 rings. The upper bound matters as much as the lower one:
+        // Measured at 127 rings, up from 78 before the warp test stopped exempting bands shorter than
+        // their own rings' edges: a twist is exactly the case where a band is sheared, so this is the
+        // shape that exemption was quietly costing. The upper bound matters as much as the lower one:
         // without it, an implementation that recursed to `maximumSubdivisionDepth` on every span
         // would pass, and spending rings is the very thing this criterion exists to stop.
         #expect((20..<200).contains(result.transforms.count))


### PR DESCRIPTION
`needsSubdivision` split a span whenever any vertex moved further than the segmentation's `minSize` since the previous ring. That measures spacing, not accuracy. With linear shaping on a straight path the ring at t is exactly `lerp(lower, upper, t)`, so every intermediate ring lands on the ruled surface its two neighbours already span: pure cost, zero fidelity. The span floor at the same `minSize` compounded it, since it also blocked subdivision on short sections that genuinely needed it.

A cone loft emitted 1025 rings where two would do, and took 10.73s against 0.002s for the equivalent `Cylinder`. Both come out at 716 triangles, because `.simplified()` discards the excess either way, so the whole of that difference was wall clock.

The criterion is now the error itself, in two parts, both budgeted against the same tolerance.

**Chord deviation.** Build the interior rings both ways, truly interpolated and where an unsubdivided band between the end rings would put them, and split while they disagree. Three interior rings are checked rather than just the midpoint, because shaping functions symmetric about (0.5, 0.5), among them smoothstep, sine, easeInOut and smootherstep, pass exactly through their own chord's midpoint. A midpoint-only test measures zero error for those and flattens the whole S-curve into one band. The quarter points cost nothing, each becoming a half's midpoint.

**Quad warp.** Every intermediate ring lies exactly on the rulings, so the chord test is blind to the band's own shape: adjacent rulings bound a quad that is generally not planar and gets split into two triangles, and the normal part of the gap between that split and the true bilinear surface is surface the mesh does not have. It halves when the band does. Without it the three-section-with-holes loft came out 5.1% over on surface area.

**The tolerance is derived, not chosen.** Adaptive segmentation states two limits on a chord: `minSize` is the shortest worth emitting, `minAngle` the smallest turn worth resolving. Both bind at once on a circle of radius `minSize / (2·sin(minAngle/2))`, and the sagitta there is `minSize · tan(minAngle/4) / 2`, free of the radius. That is the largest chord error Cadova accepts anywhere, 0.65 µm with the defaults. `\.tolerance` plays no part: it is a fit clearance between mating parts, orders of magnitude larger, and spending it here would let the surface wander by the whole gap it exists to guarantee. That derivation lives on `Segmentation`, alongside every other value derived from those two limits.

A separate commit fixes `exactFrame`, which `Loft` is the only caller of. `frames()` resolves degenerate samples across the whole array, unwraps the sequence so it never jumps by a turn, and damps it to `maxTwistRate`. `exactFrame` returned a stored frame when the requested distance landed on a sample but rebuilt the frame from the target alone whenever it landed between two, so it disagreed with its own input everywhere except at the samples. On a vertical path tracking a skew line the stored frame and one built 1e-7 mm below it differed by up to 1.553 mm, which inflated a 4 mm thick prism's surface area by 29%. It now interpolates the bracketing angles, which are already resolved and damped, and reads 1.0e-7 mm for a 1e-7 mm step.

Measured on one machine, default segmentation:

| shape | triangles before | after | seconds before | after |
|---|---|---|---|---|
| cone loft | 716 | 716 | 10.730 | 0.184 |
| cone cylinder | 716 | 716 | 0.002 | 0.004 |
| nonlinear | 23,346 | 21,818 | 1.128 | 0.947 |
| curved | 29,016 | 27,006 | 1.310 | 1.007 |
| twisting | 21,500 | 7,792 | 1.023 | 0.426 |
| holes | 41,348 | 39,084 | 3.046 | 1.844 |

**Three existing expectations in `Loft.swift` move.** Fixed segmentation does not go through this criterion at all, so it is a neutral referee; sweeping it over 64 to 1024 segments brackets each shape, and each new value sits inside that bracket.

| test | volume | area | referee |
|---|---|---|---|
| `loft with three sections and holes` | 7853.445 to 7853.271 | 3791.824 to 3792.011 | 7850.1…7862.0 and 3791.4…3793.9 |
| `section can specify custom shaping function` | 3863.623 to 3864.480 | 1236.890 to 1237.073 | 3864.0…3864.7 and 1236.9…1237.2 |
| `section shaping overrides loft default shaping` | 2732.312 to 2732.606 | 1117.823 to 1117.979 | 2732.4…2733.4 and 1117.9…1118.3 |

All three are pinned tightly enough that the value each test carried before this change now fails it. The first had been loosened to half a unit, which admitted both the old and the new value and so pinned nothing; it measures bit-identical over three separate processes, so there was no reason for the slack.

Also worth naming: `exactFrame` now checks `isUndefined` on the tangent before building a frame from it, since a collapsed curve reports a zero direction and a frame built from one has no orientation at all. And the corner recursion resets its depth per smooth span rather than per section, since each span is bisected independently.
