### PR TITLE
Stop measuring-based modifiers from rebuilding their subtree

### DIFF
--- a/Sources/Cadova/Abstract Layer/Geometry/BuildResult.swift
+++ b/Sources/Cadova/Abstract Layer/Geometry/BuildResult.swift
@@ -131,3 +131,45 @@ extension _BuildResult: Geometry {
         self
     }
 }
+
+/// A geometry that stands in for another one whose build has already been performed.
+///
+/// Reader operations — `measuring`, `separated`, `readingConcrete`, `evaluating` — have to build
+/// their target before they can hand anything to their closure. Handing the *source* geometry back
+/// to that closure makes the closure's result build the same subtree all over again, so nesting `k`
+/// readers walks the base `2^k` times. Handing back the finished `BuildResult` avoids the rebuild,
+/// but freezes the build: `BuildResult` builds to itself, so an environment modifier applied inside
+/// the closure would silently do nothing.
+///
+/// This type does both. It replays the finished build when it is asked to build under the very same
+/// environment and evaluation context that produced it, and falls back to a real build of `source`
+/// under anything else — which is exactly the case where a builder closure legitimately wraps the
+/// geometry it was handed in an environment modifier.
+///
+/// The environment half of the key is exact rather than approximate: ``EnvironmentValues/id`` is
+/// regenerated on every mutation, so an unchanged `id` means an unchanged environment. The context
+/// half matters because a `BuildResult` isn't portable between contexts — a `.materialized` node
+/// only resolves in the context whose cache the generator was declared on.
+internal struct PrebuiltGeometry<D: Dimensionality>: Geometry {
+    let source: D.Geometry
+    let environmentID: UUID
+    let contextToken: GeometryCache<D2>
+    let result: BuildResult<D>
+
+    func _build(in environment: EnvironmentValues, context: EvaluationContext) async throws -> BuildResult<D> {
+        guard environment.id == environmentID, context.identityToken === contextToken else {
+            return try await context.buildResult(for: source, in: environment)
+        }
+        return result
+    }
+}
+
+internal extension BuildResult {
+    /// A geometry that replays this build when asked for it under `environment` in `context`, and
+    /// builds `source` from scratch under anything else.
+    func standingIn(for source: D.Geometry, in environment: EnvironmentValues, context: EvaluationContext) -> D.Geometry {
+        PrebuiltGeometry(
+            source: source, environmentID: environment.id, contextToken: context.identityToken, result: self
+        )
+    }
+}

--- a/Sources/Cadova/Abstract Layer/Geometry/BuildResult.swift
+++ b/Sources/Cadova/Abstract Layer/Geometry/BuildResult.swift
@@ -146,18 +146,19 @@ extension _BuildResult: Geometry {
 /// under anything else — which is exactly the case where a builder closure legitimately wraps the
 /// geometry it was handed in an environment modifier.
 ///
-/// The environment half of the key is exact rather than approximate: ``EnvironmentValues/id`` is
-/// regenerated on every mutation, so an unchanged `id` means an unchanged environment. The context
-/// half matters because a `BuildResult` isn't portable between contexts — a `.materialized` node
-/// only resolves in the context whose cache the generator was declared on.
+/// Both halves of the key are exact. ``EnvironmentValues/id`` is regenerated on every mutation, so
+/// an unchanged `id` means an unchanged environment. The context half matters because a
+/// `BuildResult` isn't portable between contexts: a `.materialized` node only resolves in the
+/// context whose cache the generator was declared on, and more than one context can be alive at
+/// once, since each `ModelFileGenerator` holds its own.
 internal struct PrebuiltGeometry<D: Dimensionality>: Geometry {
     let source: D.Geometry
     let environmentID: UUID
-    let contextToken: GeometryCache<D2>
+    let contextID: UUID
     let result: BuildResult<D>
 
     func _build(in environment: EnvironmentValues, context: EvaluationContext) async throws -> BuildResult<D> {
-        guard environment.id == environmentID, context.identityToken === contextToken else {
+        guard environment.id == environmentID, context.id == contextID else {
             return try await context.buildResult(for: source, in: environment)
         }
         return result
@@ -169,7 +170,7 @@ internal extension BuildResult {
     /// builds `source` from scratch under anything else.
     func standingIn(for source: D.Geometry, in environment: EnvironmentValues, context: EvaluationContext) -> D.Geometry {
         PrebuiltGeometry(
-            source: source, environmentID: environment.id, contextToken: context.identityToken, result: self
+            source: source, environmentID: environment.id, contextID: context.id, result: self
         )
     }
 }

--- a/Sources/Cadova/Abstract Layer/Operations/Edge Finding/ReadEdges.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/Edge Finding/ReadEdges.swift
@@ -5,7 +5,7 @@ internal struct ReadEdges: Geometry {
 
     let body: any Geometry3D
     let query: EdgeQuery
-    let action: @Sendable (BuildResult<D3>, [FoundEdge]) -> any Geometry3D
+    let action: @Sendable (any Geometry3D, [FoundEdge]) -> any Geometry3D
 
     func _build(in environment: EnvironmentValues, context: EvaluationContext) async throws -> BuildResult<D3> {
         let bodyResult = try await context.buildResult(for: body, in: environment)
@@ -21,7 +21,12 @@ internal struct ReadEdges: Geometry {
             try await context.result(for: $0.geometry, in: maskEnvironment).concrete
         }
         let edges = EdgeExtractor.edges(in: concreteResult.concrete, matching: query, maskManifolds: maskManifolds)
-        return try await context.buildResult(for: action(bodyResult, edges), in: environment)
+        // Handing the closure the raw `BuildResult` would build to itself, so a closure that wraps
+        // the geometry in an environment modifier would silently get no rebuild. The stand-in
+        // replays the finished build under this environment and context, and does a real build of
+        // `body` under any other.
+        let standIn = bodyResult.standingIn(for: body, in: environment, context: context)
+        return try await context.buildResult(for: action(standIn, edges), in: environment)
     }
 }
 
@@ -36,8 +41,10 @@ public extension Geometry3D {
     /// }
     /// ```
     ///
-    /// The `geometry` parameter of the closure is the already-evaluated body; operations
-    /// on it hit the evaluation cache, so the geometry is not evaluated twice.
+    /// The `geometry` parameter of the closure stands in for the body that was just built: building
+    /// it again under the same environment replays that build rather than walking the body a second
+    /// time. A closure that wraps it in an environment modifier still gets a real build, under the
+    /// environment it asked for.
     ///
     /// - Parameters:
     ///   - query: The criteria used to select edges. Defaults to `.all`.

--- a/Sources/Cadova/Abstract Layer/Operations/Evaluate.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/Evaluate.swift
@@ -42,6 +42,27 @@ public struct Evaluate<D: Dimensionality>: Geometry {
     }
 }
 
+/// The receiver-taking form of ``Evaluate``, used by ``Geometry/evaluating(_:)``.
+///
+/// It builds `source` once up front and hands the closure a stand-in for it, so reads of that
+/// geometry through the evaluator — and the geometry the closure returns — reuse that build instead
+/// of walking the subtree again for each one.
+internal struct EvaluateSource<Input: Dimensionality, D: Dimensionality>: Geometry {
+    let source: Input.Geometry
+    let action: @Sendable (Input.Geometry, GeometryEvaluator) async -> D.Geometry
+
+    func _build(in environment: EnvironmentValues, context: EvaluationContext) async throws -> BuildResult<D> {
+        let sourceResult = try await context.buildResult(for: source, in: environment)
+        let evaluator = GeometryEvaluator(context: context, environment: environment)
+        let standIn = sourceResult.standingIn(for: source, in: environment, context: context)
+        let produced = await action(standIn, evaluator)
+        if let error = await evaluator.firstError {
+            throw error
+        }
+        return try await context.buildResult(for: produced, in: environment)
+    }
+}
+
 public extension Geometry {
     /// Performs several geometry reads inside one closure, then builds new geometry from the results.
     ///
@@ -53,9 +74,14 @@ public extension Geometry {
     /// code, loops, and `let` bindings.
     ///
     /// The evaluator runs in the same evaluation context and environment that the surrounding pipeline
-    /// uses, so reads share the same cache. Reading the same geometry several times inside one
-    /// `evaluating` block costs no more than reading it once. The evaluator can read any geometry in
-    /// scope — the closure's input, geometry captured from outer scope, or geometry built on the fly.
+    /// uses, so reads share the same cache. The evaluator can read any geometry in scope — the
+    /// closure's input, geometry captured from outer scope, or geometry built on the fly.
+    ///
+    /// The closure's input is built once, before the closure runs, so reading it repeatedly — and
+    /// returning geometry derived from it — costs no more than reading it once. Other geometry is
+    /// cheaper on repeat reads but not free: the mesh behind it is cached by node, so it is realized
+    /// only once, but each read still walks that geometry's abstract tree again to arrive at the node.
+    /// Bind such a value to a `let` if you need it more than once.
     ///
     /// ```swift
     /// shape.evaluating { g, eval in
@@ -80,8 +106,8 @@ public extension Geometry {
     func evaluating<Output: Dimensionality>(
         @GeometryBuilder<Output> _ action: @Sendable @escaping (D.Geometry, GeometryEvaluator) async -> Output.Geometry
     ) -> Output.Geometry {
-        Evaluate { eval in
-            await action(self, eval)
+        EvaluateSource(source: self) { geometry, eval in
+            await action(geometry, eval)
         }
     }
 }

--- a/Sources/Cadova/Abstract Layer/Operations/Measure.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/Measure.swift
@@ -4,7 +4,11 @@ import Foundation
 fileprivate struct Measure<Input: Dimensionality, D: Dimensionality>: Geometry {
     let target: [Input.Geometry]
     let scope: MeasurementScope
-    let builder: @Sendable ([Measurements<Input>]) -> D.Geometry
+    // The builder receives stand-ins for the targets rather than the targets themselves, so that
+    // building whatever it returns replays the build performed here instead of walking the same
+    // subtree a second time. A stand-in that's handed a different environment — because the builder
+    // wrapped it in an environment modifier — still rebuilds its target for real.
+    let builder: @Sendable ([Input.Geometry], [Measurements<Input>]) -> D.Geometry
 
     @_specialize(exported: false, where Input == D2, D == D2)
     @_specialize(exported: false, where Input == D2, D == D3)
@@ -15,7 +19,10 @@ fileprivate struct Measure<Input: Dimensionality, D: Dimensionality>: Geometry {
         let measurements = try await buildResults.asyncMap {
             try await Measurements(buildResult: $0, scope: scope, context: context)
         }
-        let generatedGeometry = builder(measurements)
+        let standIns = zip(target, buildResults).map { source, result in
+            result.standingIn(for: source, in: environment, context: context)
+        }
+        let generatedGeometry = builder(standIns, measurements)
         return try await context.buildResult(for: generatedGeometry, in: environment)
     }
 }
@@ -44,8 +51,8 @@ public extension Geometry {
         _ scope: MeasurementScope = .solidParts,
         @GeometryBuilder<Output> _ builder: @Sendable @escaping (D.Geometry, D.Measurements) -> Output.Geometry
     ) -> Output.Geometry {
-        Measure(target: [self], scope: scope) {
-            builder(self, $0[0])
+        Measure(target: [self], scope: scope) { targets, measurements in
+            builder(targets[0], measurements[0])
         }
     }
 
@@ -127,7 +134,7 @@ public func measureBounds<Input: Dimensionality, D: Dimensionality>(
     scope: MeasurementScope = .solidParts,
     reader: @Sendable @escaping ([BoundingBox<Input>?]) -> D.Geometry
 ) -> D.Geometry {
-    Measure(target: targets, scope: scope) { measurements in
+    Measure(target: targets, scope: scope) { _, measurements in
         reader(measurements.map(\.boundingBox))
     }
 }

--- a/Sources/Cadova/Abstract Layer/Operations/ReadConcrete.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/ReadConcrete.swift
@@ -3,19 +3,22 @@ import Manifold3D
 
 internal struct ReadConcrete<Input: Dimensionality, Output: Dimensionality>: Geometry {
     let source: Input.Geometry
-    let action: @Sendable (Input.Concrete, BuildResult<Input>) -> Output.Geometry
+    // The action's second argument is a stand-in for `source` that replays the build performed here,
+    // so returning geometry derived from it doesn't walk the source subtree a second time.
+    let action: @Sendable (Input.Concrete, Input.Geometry) -> Output.Geometry
 
     func _build(in environment: EnvironmentValues, context: EvaluationContext) async throws -> BuildResult<Output> {
         let bodyResult = try await context.buildResult(for: source, in: environment)
         let concreteResult = try await context.result(for: bodyResult.node)
-        return try await context.buildResult(for: action(concreteResult.concrete, bodyResult), in: environment)
+        let standIn = bodyResult.standingIn(for: source, in: environment, context: context)
+        return try await context.buildResult(for: action(concreteResult.concrete, standIn), in: environment)
     }
 }
 
 internal extension Geometry {
-    // Concrete + Result
+    // Concrete + the source geometry, pre-built
     func readingConcrete<Output: Dimensionality>(
-        @GeometryBuilder<Output> _ action: @Sendable @escaping (D.Concrete, BuildResult<D>) -> Output.Geometry
+        @GeometryBuilder<Output> _ action: @Sendable @escaping (D.Concrete, D.Geometry) -> Output.Geometry
     ) -> Output.Geometry {
         ReadConcrete(source: self, action: action)
     }

--- a/Sources/Cadova/Abstract Layer/Operations/ReadOutlines.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/ReadOutlines.swift
@@ -14,8 +14,8 @@ public extension Geometry2D {
     func readingOutlines<D: Dimensionality>(
         @GeometryBuilder<D> _ reader: @escaping @Sendable (_ geometry: any Geometry2D, _ paths: [BezierPath2D]) -> D.Geometry
     ) -> D.Geometry {
-        readingConcrete { crossSection, _ in
-            reader(self, crossSection.polygonList().polygons.map {
+        readingConcrete { crossSection, geometry in
+            reader(geometry, crossSection.polygonList().polygons.map {
                 BezierPath2D(linesBetween: $0.vertices).closed()
             })
         }

--- a/Sources/Cadova/Abstract Layer/Operations/ReadSurfaces.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/ReadSurfaces.swift
@@ -50,13 +50,13 @@ public extension Geometry3D {
         along segment: LineSegment3D,
         @GeometryBuilder<Output> _ reader: @Sendable @escaping (_ geometry: any Geometry3D, _ crossings: [SurfaceCrossing]) -> Output.Geometry
     ) -> Output.Geometry {
-        readingConcrete { (manifold: Manifold) in
+        readingConcrete { (manifold: Manifold, geometry: any Geometry3D) in
             let hits = manifold.rayCast(from: segment.start, to: segment.end)
             let direction = segment.direction
             let crossings = hits.map {
                 SurfaceCrossing(hit: $0, origin: segment.start, direction: direction)
             }
-            return reader(self, crossings)
+            return reader(geometry, crossings)
         }
     }
 

--- a/Sources/Cadova/Abstract Layer/Operations/Separate.swift
+++ b/Sources/Cadova/Abstract Layer/Operations/Separate.swift
@@ -7,7 +7,10 @@ internal struct Separate<D: Dimensionality, Output: Dimensionality>: Geometry {
     public func _build(in environment: EnvironmentValues, context: EvaluationContext) async throws -> BuildResult<Output> {
         let result = try await context.buildResult(for: source, in: environment)
         let partCount = try await context.result(for: .decompose(result.node)).parts.count
-        let parts = (0..<partCount).map { SeparatedPart(body: source, index: $0) }
+        // Each component is built from a stand-in for the source rather than the source itself, so
+        // decomposing into n components costs one build of the source rather than n + 1.
+        let standIn = result.standingIn(for: source, in: environment, context: context)
+        let parts = (0..<partCount).map { SeparatedPart(body: standIn, index: $0) }
         return try await context.buildResult(for: reader(parts), in: environment)
     }
 }

--- a/Sources/Cadova/Node Layer/Context/EvaluationContext.swift
+++ b/Sources/Cadova/Node Layer/Context/EvaluationContext.swift
@@ -19,6 +19,19 @@ public struct _EvaluationContext: Sendable {
 internal typealias EvaluationContext = _EvaluationContext
 
 internal extension EvaluationContext {
+    /// Identifies this context. `_EvaluationContext` is a struct, but its caches are actors, so the
+    /// identity of one of them identifies every copy of the same context — and distinguishes it from
+    /// any other. Used to keep results that only make sense within one context (such as a
+    /// `.materialized` node, whose generator is declared on that context's cache) from being replayed
+    /// in another.
+    ///
+    /// This is the cache itself rather than an `ObjectIdentifier` for it. Holding the object keeps
+    /// its address from being reused: a bare identifier stored in a value that outlived its context
+    /// would compare equal to a later cache that happened to land in the same memory, and a
+    /// `.materialized` node would then be replayed into a cache that never saw its generator, which
+    /// is the one thing this check exists to prevent.
+    var identityToken: GeometryCache<D2> { cache2D }
+
     func cache<D: Dimensionality>() -> GeometryCache<D> {
         switch D.self {
         case is D2.Type: cache2D as! GeometryCache<D>

--- a/Sources/Cadova/Node Layer/Context/EvaluationContext.swift
+++ b/Sources/Cadova/Node Layer/Context/EvaluationContext.swift
@@ -7,6 +7,10 @@ import Manifold3D
 /// requirement, which every conforming type must satisfy. It isn't meant to be constructed or used
 /// directly — hence the underscore prefix.
 public struct _EvaluationContext: Sendable {
+    /// Identifies this context, so a result tied to it (such as a `.materialized` node, whose
+    /// generator lives in this context's cache) isn't replayed in another.
+    internal let id = UUID()
+
     internal let cache2D = GeometryCache<D2>()
     internal let cache3D = GeometryCache<D3>()
     internal let threeMFModelCache = ThreeMFModelCache()
@@ -19,19 +23,6 @@ public struct _EvaluationContext: Sendable {
 internal typealias EvaluationContext = _EvaluationContext
 
 internal extension EvaluationContext {
-    /// Identifies this context. `_EvaluationContext` is a struct, but its caches are actors, so the
-    /// identity of one of them identifies every copy of the same context — and distinguishes it from
-    /// any other. Used to keep results that only make sense within one context (such as a
-    /// `.materialized` node, whose generator is declared on that context's cache) from being replayed
-    /// in another.
-    ///
-    /// This is the cache itself rather than an `ObjectIdentifier` for it. Holding the object keeps
-    /// its address from being reused: a bare identifier stored in a value that outlived its context
-    /// would compare equal to a later cache that happened to land in the same memory, and a
-    /// `.materialized` node would then be replayed into a cache that never saw its generator, which
-    /// is the one thing this check exists to prevent.
-    var identityToken: GeometryCache<D2> { cache2D }
-
     func cache<D: Dimensionality>() -> GeometryCache<D> {
         switch D.self {
         case is D2.Type: cache2D as! GeometryCache<D>

--- a/Tests/Tests/BuildMemoization.swift
+++ b/Tests/Tests/BuildMemoization.swift
@@ -1,0 +1,295 @@
+import Foundation
+import Testing
+@testable import Cadova
+
+/// Reader operations — `measuring`, `separated`, `readingOutlines`, `readingSurfaces`, `evaluating` —
+/// have to build their target before they can hand anything to their closure. If the closure then
+/// receives the *source geometry* rather than what that build produced, building the closure's result
+/// walks the same subtree a second time, and nesting `k` readers walks the base `2^k` times.
+///
+/// These tests pin the build count of a leaf that counts its own `body` evaluations. They also pin the
+/// correctness constraint that keeps the memo honest: the environment a subtree is built in is part of
+/// its identity, so a closure that hands its geometry a different environment — explicitly with an
+/// environment modifier, or implicitly by transforming it, since the accumulated transform lives in
+/// the environment — must still get a real rebuild.
+struct BuildMemoizationTests {
+    // MARK: - Instrumentation
+
+    struct BuildObservation: Hashable, Sendable {
+        let segmentation: Segmentation
+        let transform: Transform3D
+    }
+
+    final class BuildCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var observations: [BuildObservation] = []
+
+        var value: Int { lock.withLock { observations.count } }
+        var recorded: [BuildObservation] { lock.withLock { observations } }
+        var recordedSegmentations: [Segmentation] { recorded.map(\.segmentation) }
+
+        func record(_ observation: BuildObservation) {
+            lock.withLock { observations.append(observation) }
+        }
+    }
+
+    /// A leaf shape that records every evaluation of its `body`, along with the environment it saw.
+    struct CountingBox: Geometry3D {
+        let counter: BuildCounter
+        var size: Double = 10
+
+        var body: any Geometry3D {
+            @Environment(\.segmentation) var segmentation
+            @Environment(\.transform) var transform
+            let _ = counter.record(.init(segmentation: segmentation, transform: transform))
+            Box(size)
+        }
+    }
+
+    /// Disjoint shells, so `separated` sees more than one component.
+    struct CountingShells: Geometry3D {
+        static let shellSize = 5.0
+        /// Wider than a shell, so consecutive shells never touch and stay separate components.
+        static let shellSpacing = 10.0
+
+        let counter: BuildCounter
+        let shellCount: Int
+
+        var body: any Geometry3D {
+            @Environment(\.segmentation) var segmentation
+            @Environment(\.transform) var transform
+            let _ = counter.record(.init(segmentation: segmentation, transform: transform))
+            Box(Self.shellSize)
+                .repeated(along: .x, in: 0..<(Self.shellSpacing * Double(shellCount)), count: shellCount)
+        }
+    }
+
+    struct CountingCircle: Geometry2D {
+        let counter: BuildCounter
+
+        var body: any Geometry2D {
+            @Environment(\.segmentation) var segmentation
+            @Environment(\.transform) var transform
+            let _ = counter.record(.init(segmentation: segmentation, transform: transform))
+            Circle(diameter: 10)
+        }
+    }
+
+    @discardableResult
+    private func build<D: Dimensionality>(
+        _ geometry: D.Geometry,
+        in environment: EnvironmentValues = .defaultEnvironment
+    ) async throws -> (context: EvaluationContext, result: BuildResult<D>) {
+        let context = EvaluationContext()
+        let result = try await context.buildResult(for: geometry, in: environment)
+        return (context, result)
+    }
+
+    // MARK: - Build counts
+
+    @Test func `a measuring closure that leaves its geometry in place builds the target once`() async throws {
+        let counter = BuildCounter()
+        let geometry = CountingBox(counter: counter)
+            .measuringBounds { geometry, box in
+                geometry.intersecting { Box(box.size * 0.5) }
+            }
+
+        try await build(geometry)
+        #expect(counter.value == 1)
+    }
+
+    @Test func `four nested measuring modifiers build the leaf once`() async throws {
+        let counter = BuildCounter()
+        var geometry: any Geometry3D = CountingBox(counter: counter)
+        for _ in 0..<4 {
+            geometry = geometry.measuringBounds { inner, box in
+                inner.intersecting { Box(box.size) }
+            }
+        }
+
+        try await build(geometry)
+        #expect(counter.value == 1)
+    }
+
+    @Test func `separated builds its source once regardless of part count`() async throws {
+        for shellCount in [1, 2, 5] {
+            let counter = BuildCounter()
+            let geometry = CountingShells(counter: counter, shellCount: shellCount)
+                .separated { components in
+                    for component in components {
+                        component
+                    }
+                }
+
+            try await build(geometry)
+            #expect(counter.value == 1, "shellCount: \(shellCount)")
+        }
+    }
+
+    @Test func `readingSurfaces builds its target once`() async throws {
+        let counter = BuildCounter()
+        let geometry = CountingBox(counter: counter)
+            .readingSurfaces(from: [5, 5, 100], in: .down) { geometry, _ in
+                geometry
+            }
+
+        try await build(geometry)
+        #expect(counter.value == 1)
+    }
+
+    @Test func `evaluating builds its target once`() async throws {
+        let counter = BuildCounter()
+        let geometry = CountingBox(counter: counter)
+            .evaluating { geometry, evaluator in
+                let _ = await evaluator.bounds(of: geometry)
+                let _ = await evaluator.bounds(of: geometry)
+                return geometry
+            }
+
+        try await build(geometry)
+        #expect(counter.value == 1)
+    }
+
+    @Test func `readingOutlines builds its target once`() async throws {
+        let counter = BuildCounter()
+        let geometry = CountingCircle(counter: counter)
+            .readingOutlines { geometry, _ in
+                geometry
+            }
+
+        try await build(geometry)
+        #expect(counter.value == 1)
+    }
+
+    @Test func `trimming builds its target once`() async throws {
+        let counter = BuildCounter()
+        try await build(CountingCircle(counter: counter).trimmed(along: .y))
+        #expect(counter.value == 1)
+    }
+
+    // `split(along:)` is two independent `trimmed(along:)` calls, so it builds its target once per
+    // half rather than the two-per-half it used to.
+    @Test func `splitting builds its target once per half`() async throws {
+        let counter = BuildCounter()
+        let geometry = CountingCircle(counter: counter)
+            .split(along: .y) { right, left in
+                right
+                left.translated(x: 20)
+            }
+
+        try await build(geometry)
+        #expect(counter.value == 2)
+    }
+
+    // MARK: - Environment correctness
+
+    // A builder closure may legitimately wrap the geometry it was handed in an environment modifier.
+    // Memoizing the build must not swallow that: the subtree has to be rebuilt under the new
+    // environment, and the result must reflect the inner environment, not the outer one.
+    @Test func `a builder closure's environment modifier still reaches the measured geometry`() async throws {
+        let counter = BuildCounter()
+        let outerSegmentation = Segmentation.fixed(11)
+        let innerSegmentation = Segmentation.fixed(23)
+
+        let geometry = CountingBox(counter: counter)
+            .measuringBounds { geometry, _ in
+                geometry.withSegmentation(innerSegmentation)
+            }
+            .withSegmentation(outerSegmentation)
+
+        try await build(geometry)
+
+        #expect(counter.recordedSegmentations == [outerSegmentation, innerSegmentation])
+    }
+
+    // The same, observed through the geometry itself rather than an environment probe: the number of
+    // segments in the produced circle must come from the closure's environment.
+    @Test func `a builder closure's segmentation change is visible in the produced geometry`() async throws {
+        let geometry = Circle(diameter: 10)
+            .measuringBounds { circle, _ in
+                circle.withSegmentation(count: 7)
+            }
+            .withSegmentation(count: 31)
+
+        let (context, result) = try await build(geometry) as (EvaluationContext, BuildResult<D2>)
+        let concrete = try await context.result(for: result.node).concrete
+        let vertexCount = concrete.polygonList().polygons.first?.vertices.count
+
+        #expect(vertexCount == 7)
+    }
+
+    // Without an environment modifier, the measured geometry keeps the outer environment.
+    @Test func `a builder closure without an environment modifier keeps the outer environment`() async throws {
+        let counter = BuildCounter()
+        let outerSegmentation = Segmentation.fixed(11)
+
+        let geometry = CountingBox(counter: counter)
+            .measuringBounds { geometry, _ in geometry }
+            .withSegmentation(outerSegmentation)
+
+        try await build(geometry)
+
+        #expect(counter.recordedSegmentations == [outerSegmentation])
+    }
+
+    // Transforming the geometry inside the closure is an environment change too: the accumulated
+    // transform lives in the environment, and geometry is allowed to read it (natural up direction,
+    // scaled tolerance and segmentation, anchors). So `aligned` and friends genuinely build their
+    // target twice — once to measure it in the untransformed frame, once to place it in the
+    // transformed one — and the two builds must see the two different transforms. This is the limit
+    // of an environment-keyed memo, not a defect in it.
+    @Test func `a measuring closure that transforms its geometry rebuilds it under the new transform`() async throws {
+        let boxSize = 12.0
+        let counter = BuildCounter()
+        try await build(CountingBox(counter: counter, size: boxSize).aligned(at: .centerXY))
+
+        #expect(counter.value == 2)
+        #expect(counter.recorded.map(\.transform)
+            == [.identity, .translation(x: -boxSize / 2, y: -boxSize / 2)])
+    }
+
+    /// The same limit holds for every member of the transform-applying family, not only `aligned`.
+    /// Each of these decides where its geometry goes, so each builds it twice: once to measure it
+    /// where it stands, once to build it where it was put. Pinning one member would leave the other
+    /// four free to change without anyone noticing.
+    @Test func `every transform-applying modifier rebuilds its geometry under the new transform`() async throws {
+        func buildCount(_ place: (CountingBox) -> any Geometry3D) async throws -> Int {
+            let counter = BuildCounter()
+            try await build(place(CountingBox(counter: counter)))
+            return counter.value
+        }
+
+        #expect(try await buildCount { $0.aligned(at: .centerXY) } == 2)
+        #expect(try await buildCount { $0.whileAligned(at: .centerXY) { $0 } } == 2)
+        #expect(try await buildCount { $0.resized(x: 20, y: 20, z: 20) } == 2)
+        #expect(try await buildCount { box in Stack(.x, spacing: 1) { box; Box(1) } } == 2)
+
+        // `within` is the one that doesn't, measured rather than assumed: it decides on a translation
+        // and applies it to the build it already has, instead of building the geometry again in the
+        // moved frame. So it takes the memo like the readers do.
+        #expect(try await buildCount { $0.within(0...20, along: .x) } == 1)
+    }
+
+    // MARK: - Stand-in scoping
+
+    // A stand-in replays a build only in the context that produced it. A `.materialized` node's
+    // generator is declared on one context's cache, so replaying such a result in a different
+    // context would hand back a node that context can't evaluate.
+    @Test func `a stand-in rebuilds rather than replaying in a different context`() async throws {
+        let counter = BuildCounter()
+        let source: any Geometry3D = CountingBox(counter: counter)
+        let environment = EnvironmentValues.defaultEnvironment
+
+        let contextA = EvaluationContext()
+        let resultA = try await contextA.buildResult(for: source, in: environment)
+        let standIn = resultA.standingIn(for: source, in: environment, context: contextA)
+        #expect(counter.value == 1)
+
+        _ = try await contextA.buildResult(for: standIn, in: environment)
+        #expect(counter.value == 1)
+
+        let contextB = EvaluationContext()
+        _ = try await contextB.buildResult(for: standIn, in: environment)
+        #expect(counter.value == 2)
+    }
+}


### PR DESCRIPTION
Reader operations must build their target before they can hand anything to their closure, but then handed the closure the source geometry rather than what that build produced. Building the closure's result therefore walked the same abstract subtree a second time, re-running user `body` code, `Mirror`-based cache-key derivation, whole-file hashing on imports, environment copies and node construction. Nested readers multiplied: four nested `measuring` modifiers walked the leaf 16 times, and `separated` walked its source once per component plus one.

**Reading the result into a local does not fix this, and neither does handing back the raw `BuildResult`.** The second walk does not happen in `buildResult(for:in:)`, which has no memo at all; it happens because `builder(self, ...)` returns a tree that still contains `self`, built later in a different call frame. Substituting into that tree is the only mechanism available. And the obvious substitution is unsound: `_BuildResult` builds to itself, so a builder closure that legitimately wraps its geometry in an environment modifier would silently get no rebuild. Two tests fail under that version and pass under this one, `a builder closure's environment modifier still reaches the measured geometry` and `a builder closure's segmentation change is visible in the produced geometry`.

So the stand-in is `PrebuiltGeometry`, about fifteen lines, immutable, `Sendable`, with no lock and no cache. It replays the finished build only under the environment and context that produced it, and does a real build of the source under anything else. `EnvironmentValues.id` is regenerated on every mutation, so the environment half of the key is exact and covers `transform` and `segmentation` along with everything else. The context half keeps a `.materialized` node from being replayed in a context whose cache never saw its generator; it holds the cache object itself rather than an `ObjectIdentifier` for it, so that a stand-in outliving its context cannot match a later cache that happened to land at the same address.

Measured on a leaf that counts its own `body` evaluations:

| operation | before | after |
|---|---|---|
| `measuring`, non-transforming closure | 2 | 1 |
| four nested `measuring` modifiers | 16 | 1 |
| `separated`, 1 / 2 / 5 components | 2 / 3 / 6 | 1 / 1 / 1 |
| `readingSurfaces` | 3 | 1 |
| `evaluating`, two reads | 3 | 1 |
| `readingOutlines` | 2 | 1 |
| `trimmed(along:)` in 2D | 2 | 1 |
| `split(along:)` in 2D | 4 | 2 |

**A closure that transforms the geometry it was handed still builds it twice, and must.** The accumulated transform lives in the environment and geometry is allowed to read it, so the placed build is a genuinely different build from the measured one. A memo that ignored the transform would be unsound. Every member of that family is pinned by a test rather than one standing in for the rest: `aligned`, `whileAligned`, `Stack` and `resized` each build twice.

`within` was measured and does not. It settles on a translation and applies it to the build it already has instead of building the geometry again in the moved frame, so it takes the memo like a reader does. That is pinned too, at one build rather than two.

`readingEdges` was the one reader still handing its action a raw `BuildResult`, on exactly the pattern described above as unsound, while its documentation claimed the geometry is not evaluated twice. It now takes the stand-in like the others.

`evaluating`'s documentation is corrected. It claimed repeated reads of any geometry cost no more than one. That is true of the mesh, which is cached by node, and now true of the closure's own input, but not of other geometry: each read still walks that geometry's abstract tree.

No existing test expectations change. One new test file.
