### PR TITLE
Propagate build failures to the caller and to the exit status

### DIFF
--- a/Sources/Cadova/Cadova.docc/ModelAndProject.md
+++ b/Sources/Cadova/Cadova.docc/ModelAndProject.md
@@ -93,6 +93,47 @@ Control compression level for 3MF files. Higher compression reduces file size bu
 await Model("spade", options: .compression(.smallest)) { ... }
 ```
 
+## When a Model Fails
+
+A model can fail to build — geometry that can't be evaluated, an import that isn't there, a builder
+that produces no geometry at all — or fail to be written, because the destination directory is
+read-only or the disk is full.
+
+Within a `Project`, one failure never stops the rest of the build. Every model that can be built
+still is, each failure is logged, and then the program ends once, with a **non-zero exit status**.
+That last part is what lets a shell, a Makefile or a CI job tell a failed build from a successful
+one:
+
+```sh
+swift run && open Models/knob.3mf
+```
+
+Two limits on that are worth knowing, because both follow from where the process ends. A standalone
+`Model` is its own top-level build, so it ends the program as soon as it fails: a script listing
+several bare models stops at the first one that fails, and wrapping them in a `Project` is what
+builds them all. And a `Group` whose directory cannot be created skips the models inside it, since
+there is nowhere left to write them.
+
+`Project` also returns a ``BuildOutcome`` describing what happened, which you can inspect instead of
+letting the failure end the process:
+
+```swift
+let outcome = await BuildFailureBehavior.report.whileCurrent {
+    await Project(packageRelative: "Models") {
+        await Model("knob") { Knob() }
+    }
+}
+
+for failure in outcome.failures {
+    print(failure)          // "Failed to write model "knob" to …: …"
+}
+```
+
+``BuildFailureBehavior/report`` is what you want if Cadova is embedded in a program that has to stay
+alive, and it's also what a test that deliberately builds a broken model needs, since the default
+behavior would end the test process. A standalone `Model` has no return value to carry an outcome,
+so under `.report` its failures are only logged.
+
 ## Programmatic API
 
 For GUI applications, servers, or other contexts where you need control over where and how files are saved, use ``ModelFileGenerator`` instead of ``Model``.

--- a/Sources/Cadova/Concrete Layer/Build/Build.swift
+++ b/Sources/Cadova/Concrete Layer/Build/Build.swift
@@ -24,8 +24,14 @@ extension [BuildDirective] {
     }
 }
 
-enum BuildError: Error {
+enum BuildError: Error, CustomStringConvertible {
     case noGeometry
+
+    var description: String {
+        switch self {
+        case .noGeometry: "The model contains no geometry"
+        }
+    }
 }
 
 fileprivate extension Geometry2D {
@@ -48,11 +54,15 @@ internal extension EnvironmentValues {
 }
 
 internal protocol ModelBuildable: Sendable {
+    /// Builds and writes everything this buildable contains.
+    ///
+    /// Never throws: one model failing must not cancel the rest of the build, so failures are
+    /// collected into the returned outcome and handed up to whoever started the build.
     func build(
         environment inheritedEnvironment: EnvironmentValues,
         context: EvaluationContext,
         options inheritedOptions: ModelOptions?,
         URL directory: URL?,
         filterPath: [String]
-    ) async -> [URL]
+    ) async -> BuildOutcome
 }

--- a/Sources/Cadova/Concrete Layer/Build/BuildOutcome.swift
+++ b/Sources/Cadova/Concrete Layer/Build/BuildOutcome.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// One thing that went wrong while building a ``Model``, a ``Group`` or a `Project`.
+///
+/// A failure never stops the rest of the build: the models that can be built still are, and every
+/// failure is collected into the ``BuildOutcome`` the build returns.
+public struct BuildFailure: Error, Sendable, CustomStringConvertible {
+    /// What the build was doing when it failed.
+    public enum Stage: Sendable, Hashable {
+        /// Assembling the model's geometry tree and deciding which output format it takes.
+        case evaluating
+
+        /// Producing the output file's contents and saving them to disk.
+        ///
+        /// Output providers generate their contents on demand, so an error in the geometry itself
+        /// usually surfaces here rather than in ``evaluating``.
+        case writing
+
+        /// Creating the directory that output files are written to.
+        case creatingDirectory
+    }
+
+    /// The stage of the build that failed.
+    public let stage: Stage
+
+    /// The name of the model that failed, prefixed with the names of the groups containing it, or
+    /// `nil` when the failure isn't attributable to a single model.
+    public let modelName: String?
+
+    /// The file or directory involved, when the failure happened late enough for it to be known.
+    public let url: URL?
+
+    /// The error that caused the failure.
+    public let underlyingError: any Error
+
+    internal init(stage: Stage, modelName: String?, url: URL?, underlyingError: any Error) {
+        self.stage = stage
+        self.modelName = modelName
+        self.url = url
+        self.underlyingError = underlyingError
+    }
+
+    public var description: String {
+        let subject = modelName.map { "model \"\($0)\"" } ?? "model"
+        let action = switch stage {
+        case .evaluating: "Failed to build \(subject)"
+        case .writing: "Failed to write \(subject)" + (url.map { " to \($0.path)" } ?? "")
+        case .creatingDirectory: "Failed to create output directory" + (url.map { " \($0.path)" } ?? "")
+        }
+        return "\(action): \(underlyingError.descriptiveString)"
+    }
+}
+
+extension BuildFailure: LocalizedError {
+    public var errorDescription: String? { description }
+}
+
+/// The result of building a ``Model``, a ``Group`` or a `Project`.
+///
+/// Everything that could be built was; anything that couldn't is listed in ``failures``. See
+/// ``BuildFailureBehavior`` for what happens to the process when ``failures`` isn't empty.
+public struct BuildOutcome: Sendable {
+    /// The output files that this build created and that didn't exist beforehand.
+    ///
+    /// Files that were overwritten are deliberately left out: this is what gets revealed in the
+    /// Finder or the file manager, and a file that's already open in a viewer doesn't need
+    /// pointing out again.
+    public let createdFiles: [URL]
+
+    /// Everything that went wrong, in no particular order.
+    public let failures: [BuildFailure]
+
+    /// Whether the whole build succeeded.
+    public var succeeded: Bool { failures.isEmpty }
+
+    internal init(createdFiles: [URL] = [], failures: [BuildFailure] = []) {
+        self.createdFiles = createdFiles
+        self.failures = failures
+    }
+
+    internal init(combining outcomes: some Sequence<BuildOutcome>) {
+        createdFiles = outcomes.flatMap(\.createdFiles)
+        failures = outcomes.flatMap(\.failures)
+    }
+}
+
+internal extension BuildOutcome {
+    /// Ends a top-level build, applying the current ``BuildFailureBehavior`` to any failures. Under
+    /// the default behavior that means ending the process, which is what the name says out loud.
+    ///
+    /// Called by `Project` and by a standalone ``Model``, and by nothing in between: a group's
+    /// failures belong to the project that contains it.
+    func terminateIfFailed() {
+        guard failures.isEmpty == false else { return }
+
+        logger.error("Build failed with \(failures.count) error\(failures.count == 1 ? "" : "s").")
+
+        if BuildFailureBehavior.current == .terminateProcess {
+            exit(EXIT_FAILURE)
+        }
+    }
+}
+
+internal extension FileManager {
+    /// Creates a build's output directory, reporting a failure instead of throwing one.
+    ///
+    /// Without this directory there is nowhere for any of the models below it to go, so the failure
+    /// belongs to the directory and is reported once, rather than once per model that then can't be
+    /// saved into it.
+    func createOutputDirectory(at url: URL, modelName: String?) -> BuildFailure? {
+        do {
+            try createDirectory(at: url, withIntermediateDirectories: true)
+            return nil
+        } catch {
+            let failure = BuildFailure(
+                stage: .creatingDirectory, modelName: modelName, url: url, underlyingError: error
+            )
+            logger.error("\(failure)")
+            return failure
+        }
+    }
+}
+
+/// What ``Model`` and `Project` do when part of a build fails.
+///
+/// ``Model`` and `Project` are the entry points of a command-line model program, so by default a
+/// failed build ends that program with a non-zero exit status. That's the only signal a shell, a
+/// Makefile or a CI job can act on; a log line isn't one, and neither is the returned
+/// ``BuildOutcome``, since nothing obliges the caller to look at it.
+///
+/// Choose ``report`` when Cadova is embedded in a program that has to stay alive — although an
+/// application or a server is usually better served by ``ModelFileGenerator``, which reports every
+/// failure by throwing.
+///
+/// ```swift
+/// let outcome = await BuildFailureBehavior.report.whileCurrent {
+///     await Project(root: outputDirectory) {
+///         await Model("widget") { Widget() }
+///     }
+/// }
+/// for failure in outcome.failures {
+///     presentToUser(failure)
+/// }
+/// ```
+public enum BuildFailureBehavior: Sendable, Hashable {
+    /// Log the failures and end the process with a non-zero exit status once the build has
+    /// finished. This is the default.
+    case terminateProcess
+
+    /// Log the failures and return normally, leaving them to the caller to act on through the
+    /// returned ``BuildOutcome``.
+    ///
+    /// A standalone ``Model`` has no return value to carry an outcome, so under this behavior its
+    /// failures are only logged.
+    case report
+
+    /// The behavior in effect for the current task.
+    @TaskLocal public static var current: BuildFailureBehavior = .terminateProcess
+
+    /// Runs `body` with this behavior in effect.
+    public func whileCurrent<T>(_ body: () async throws -> T) async rethrows -> T {
+        try await Self.$current.withValue(self, operation: body)
+    }
+}

--- a/Sources/Cadova/Concrete Layer/Build/Group/Group.swift
+++ b/Sources/Cadova/Concrete Layer/Build/Group/Group.swift
@@ -85,7 +85,7 @@ public struct Group: Sendable, ModelBuildable {
         options inheritedOptions: ModelOptions?,
         URL directory: URL?,
         filterPath: [String]
-    ) async -> [URL] {
+    ) async -> BuildOutcome {
         let directives = await ModelContext(isCollectingModels: true).whileCurrent {
             await inheritedEnvironment.whileCurrent {
                 await self.directives()
@@ -99,12 +99,18 @@ public struct Group: Sendable, ModelBuildable {
         let currentFilterPath: [String]
         if let name {
             currentFilterPath = filterPath + [name]
-            if let parent = directory {
-                outputDirectory = parent.appendingPathComponent(name, isDirectory: true)
+            let groupDirectory = if let parent = directory {
+                parent.appendingPathComponent(name, isDirectory: true)
             } else {
-                outputDirectory = URL(expandingFilePath: name)
+                URL(expandingFilePath: name)
             }
-            try? FileManager().createDirectory(at: outputDirectory!, withIntermediateDirectories: true)
+
+            if let failure = FileManager().createOutputDirectory(
+                at: groupDirectory, modelName: currentFilterPath.joined(separator: "/")
+            ) {
+                return BuildOutcome(failures: [failure])
+            }
+            outputDirectory = groupDirectory
         } else {
             currentFilterPath = filterPath
             outputDirectory = directory
@@ -117,10 +123,8 @@ public struct Group: Sendable, ModelBuildable {
         let filteredModels = models.filter { $0.isIncluded(by: filterNames, in: currentFilterPath) }
         let buildables: [any ModelBuildable] = groups + filteredModels
 
-        let urls = await buildables.asyncMap {
+        return BuildOutcome(combining: await buildables.asyncMap {
             await $0.build(environment: environment, context: context, options: options, URL: outputDirectory, filterPath: currentFilterPath)
-        }.joined()
-
-        return Array(urls)
+        })
     }
 }

--- a/Sources/Cadova/Concrete Layer/Build/Model/Model.swift
+++ b/Sources/Cadova/Concrete Layer/Build/Model/Model.swift
@@ -14,6 +14,11 @@ import Foundation
 /// Models can also be grouped within a `Project` to share environment settings and metadata
 /// across multiple output files.
 ///
+/// A model that can't be built or written is logged and then ends the process with a non-zero exit
+/// status, so that whatever ran the program can tell that the build failed. See
+/// ``BuildFailureBehavior`` for how to inspect failures instead of ending the process, and
+/// ``BuildOutcome`` for what `Project` reports.
+///
 /// For fine-grained control of file output, see ``ModelFileGenerator``.
 ///
 public struct Model: Sendable, ModelBuildable {
@@ -85,9 +90,9 @@ public struct Model: Sendable, ModelBuildable {
         self.options = .init(options)
 
         if ModelContext.current.isCollectingModels == false {
-            if let url = await build().first {
-                try? Platform.revealFiles([url])
-            }
+            let outcome = await build()
+            try? Platform.revealFiles(outcome.createdFiles)
+            outcome.terminateIfFailed()
         }
     }
 
@@ -97,8 +102,9 @@ public struct Model: Sendable, ModelBuildable {
         options inheritedOptions: ModelOptions? = nil,
         URL directory: URL? = nil,
         filterPath: [String] = []
-    ) async -> [URL] {
+    ) async -> BuildOutcome {
         logger.info("Generating \"\(name)\"...")
+        let qualifiedName = filterName(in: filterPath)
 
         var directives = inheritedEnvironment.whileCurrent {
             self.directives()
@@ -137,26 +143,33 @@ public struct Model: Sendable, ModelBuildable {
                 logger.warning("\(warning)")
             }
 
-        } catch BuildError.noGeometry {
-            logger.error("No geometry for model \"\(name)\"")
-            return []
-
         } catch {
-            logger.error("Cadova caught an error while evaluating model \"\(name)\":\n\(error)\n")
-            return []
+            let failure = BuildFailure(stage: .evaluating, modelName: qualifiedName, url: nil, underlyingError: error)
+            logger.error("\(failure)")
+            return BuildOutcome(failures: [failure])
         }
 
         let url = baseURL.appendingPathExtension(provider.fileExtension)
         let fileExisted = FileManager().fileExists(atPath: url.path(percentEncoded: false))
 
         // Shared by every path below — never called more than once per build.
-        func write() async {
+        func write() async -> BuildFailure? {
             do {
                 try await provider.writeOutput(to: url, context: context)
                 logger.info("Wrote model to \(url.path)")
+                return nil
             } catch {
-                logger.error("Failed to save model file to \(url.path): \(error.descriptiveString)")
+                let failure = BuildFailure(stage: .writing, modelName: qualifiedName, url: url, underlyingError: error)
+                logger.error("\(failure)")
+                return failure
             }
+        }
+
+        func outcome(_ failure: BuildFailure?) -> BuildOutcome {
+            BuildOutcome(
+                createdFiles: fileExisted || failure != nil ? [] : [url],
+                failures: [failure].compactMap { $0 }
+            )
         }
 
         if provider.isLikelyToReachLiveLinkListener(destination: url) {
@@ -171,16 +184,15 @@ public struct Model: Sendable, ModelBuildable {
             let writeTask = Task(priority: .utility) { await write() }
 
             _ = await pushTask.value
-            await writeTask.value
-            return fileExisted ? [] : [url]
+            return outcome(await writeTask.value)
         }
 
         // No listener expected — plain async-let avoids the Task-split overhead above.
         async let liveLinkPush: Bool = provider.pushToLiveLink(destination: url, context: context)
-        await write()
+        let writeFailure = await write()
         _ = await liveLinkPush
 
-        return fileExisted ? [] : [url]
+        return outcome(writeFailure)
     }
 }
 

--- a/Sources/Cadova/Concrete Layer/Build/Project/Project.swift
+++ b/Sources/Cadova/Concrete Layer/Build/Project/Project.swift
@@ -31,6 +31,13 @@ import Foundation
 ///   - content: A result builder that asynchronously returns an array of directives. It can include `Model` instances
 ///     to be evaluated and saved, as well as `Environment` and `Metadata` directives that set project-wide defaults.
 ///
+/// - Returns: A ``BuildOutcome`` listing the files that were created and every model that failed.
+///
+/// One model failing doesn't stop the others: every model that can be built still is, and the
+/// failures are collected into the returned outcome. Once the build has finished, the process ends
+/// with a non-zero exit status if anything failed — see ``BuildFailureBehavior`` to inspect the
+/// outcome instead.
+///
 /// ### Example
 /// ```swift
 /// await Project(root: "pieces", options: .format3D(.stl)) {
@@ -62,18 +69,21 @@ import Foundation
 /// }
 /// ```
 ///
+@discardableResult
 public func Project(
     root url: URL?,
     options: ModelOptions...,
     @ProjectContentBuilder content: @Sendable @escaping () async -> [BuildDirective]
-) async {
+) async -> BuildOutcome {
     // Collect directives
     let directives = await ModelContext(isCollectingModels: true).whileCurrent {
         await content()
     }
 
-    if let url {
-        try? FileManager().createDirectory(at: url, withIntermediateDirectories: true)
+    if let url, let failure = FileManager().createOutputDirectory(at: url, modelName: nil) {
+        let outcome = BuildOutcome(failures: [failure])
+        outcome.terminateIfFailed()
+        return outcome
     }
 
     var combinedOptions = ModelOptions(options + directives.compactMap(\.options))
@@ -89,7 +99,7 @@ public func Project(
 
     // Build models and groups
     let groups = directives.compactMap(\.group)
-    guard models.isEmpty == false || groups.isEmpty == false else { return }
+    guard models.isEmpty == false || groups.isEmpty == false else { return BuildOutcome() }
     let context = EvaluationContext()
 
     let constantEnvironment = environment
@@ -98,18 +108,21 @@ public func Project(
     let filteredModels = models.filter { $0.isIncluded(by: filterNames, in: []) }
     let buildables: [any ModelBuildable] = groups + filteredModels
     let finalOptions = combinedOptions
-    let urls = await buildables.asyncMap {
+    let outcome = BuildOutcome(combining: await buildables.asyncMap {
         await $0.build(environment: constantEnvironment, context: context, options: finalOptions, URL: url, filterPath: [])
-    }.joined()
+    })
 
-    try? Platform.revealFiles(Array(urls))
+    try? Platform.revealFiles(outcome.createdFiles)
+    outcome.terminateIfFailed()
+    return outcome
 }
 
+@discardableResult
 public func Project(
     root: String? = nil,
     options: ModelOptions...,
     @ProjectContentBuilder content: @Sendable @escaping () async -> [BuildDirective]
-) async {
+) async -> BuildOutcome {
     await Project(
         root: root.map { URL(expandingFilePath: $0) },
         options: .init(options),
@@ -140,17 +153,18 @@ public func Project(
 ///
 /// This will save models to `<package-root>/Models/`.
 ///
+@discardableResult
 public func Project(
     packageRelative root: String,
     sourceFile: String = #filePath,
     options: ModelOptions...,
     @ProjectContentBuilder content: @Sendable @escaping () async -> [BuildDirective]
-) async {
+) async -> BuildOutcome {
     let sourceURL = URL(filePath: sourceFile)
     let packageRoot = sourceURL.packageRootURL ?? sourceURL.deletingLastPathComponent()
     let outputURL = packageRoot.appending(path: root, directoryHint: .isDirectory)
 
-    await Project(
+    return await Project(
         root: outputURL,
         options: .init(options),
         content: content

--- a/Tests/Tests/Build.swift
+++ b/Tests/Tests/Build.swift
@@ -216,19 +216,24 @@ struct BuildTests {
         #expect(files.contains("with-environment.3mf"))
     }
 
-    @Test func `Model with no geometry produces no file`() async throws {
+    @Test func `Model with no geometry produces no file and reports a failure`() async throws {
         let tempDir = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        await Project(root: tempDir) {
-            await Model("empty-model") {
-                // No geometry
+        // Without `.report`, a build with a failure in it ends the process — which is the point of
+        // the default behavior, but not something a test process can survive.
+        let outcome = await BuildFailureBehavior.report.whileCurrent {
+            await Project(root: tempDir) {
+                await Model("empty-model") {
+                    // No geometry
+                }
             }
         }
 
         let files = try FileManager.default.contentsOfDirectory(atPath: tempDir.path)
         #expect(files.isEmpty)
+        #expect(outcome.failures.map(\.modelName) == ["empty-model"])
     }
 
     // MARK: - Group Tests

--- a/Tests/Tests/BuildErrorPropagation.swift
+++ b/Tests/Tests/BuildErrorPropagation.swift
@@ -1,0 +1,220 @@
+import Foundation
+import Testing
+@testable import Cadova
+
+/// A geometry that can never be built: the file it imports does not exist.
+private var unbuildableGeometry: any Geometry3D {
+    Import(model: URL(filePath: "/nonexistent/cadova-missing-model.3mf"))
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+/// Whether making a directory read-only actually stops writes into it.
+///
+/// POSIX permission bits do not govern directory writes on Windows, so a directory made read-only
+/// there stays writable, and a test built on that premise would assert the opposite of what happens.
+/// Skipping is honest where passing would not be.
+private let readOnlyDirectoriesAreEnforced = {
+    #if os(Windows)
+    false
+    #else
+    true
+    #endif
+}()
+
+/// Makes `directory` unwritable for the duration of `body`, then puts it back so that it can be
+/// deleted again.
+@discardableResult
+private func withReadOnlyDirectory<T>(_ directory: URL, _ body: () async throws -> T) async rethrows -> T {
+    try? FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: directory.path)
+    defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path) }
+    return try await body()
+}
+
+struct BuildErrorPropagationTests {
+    init() {
+        Platform.revealingFilesDisabled = true
+    }
+
+    // MARK: - A failing model is reported to whoever started the build
+
+    @Test func `a project reports a failing model while still writing the good ones`() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let outcome = await BuildFailureBehavior.report.whileCurrent {
+            await Project(root: directory) {
+                await Model("good") { Box(10) }
+                await Model("bad") { unbuildableGeometry }
+            }
+        }
+
+        let files = Set(try FileManager.default.contentsOfDirectory(atPath: directory.path))
+        #expect(files.contains("good.3mf"))
+        #expect(files.contains("bad.3mf") == false)
+
+        #expect(outcome.succeeded == false)
+        let failure = try #require(outcome.failures.first)
+        #expect(outcome.failures.count == 1)
+        #expect(failure.modelName == "bad")
+        // The 3MF provider generates its contents on demand, so the missing import surfaces when
+        // the file is produced rather than while the geometry tree is being assembled.
+        #expect(failure.stage == .writing)
+    }
+
+    @Test func `a model containing no geometry is a failure, not a silent no-op`() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let outcome = await BuildFailureBehavior.report.whileCurrent {
+            await Project(root: directory) {
+                await Model("empty") {}
+            }
+        }
+
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty)
+        #expect(outcome.failures.map(\.modelName) == ["empty"])
+        #expect(outcome.failures.first?.underlyingError is BuildError)
+    }
+
+    @Test func `a failing model inside a group is named by its full path`() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let outcome = await BuildFailureBehavior.report.whileCurrent {
+            await Project(root: directory) {
+                await Group("parts") {
+                    await Model("bad") { unbuildableGeometry }
+                }
+            }
+        }
+
+        #expect(outcome.failures.map(\.modelName) == ["parts/bad"])
+    }
+
+    // MARK: - The process exit status
+
+    @Test func `a project whose model fails exits with a non-zero status`() async throws {
+        await #expect(processExitsWith: .failure) {
+            Platform.revealingFilesDisabled = true
+            let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+            await Project(root: directory) {
+                await Model("good") { Box(10) }
+                await Model("bad") { Import(model: URL(filePath: "/nonexistent/cadova-missing-model.3mf")) }
+            }
+        }
+    }
+
+    @Test func `a standalone model that fails exits with a non-zero status`() async throws {
+        await #expect(processExitsWith: .failure) {
+            Platform.revealingFilesDisabled = true
+            let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+            await Model(directory.appending(path: "bad").path) {
+                Import(model: URL(filePath: "/nonexistent/cadova-missing-model.3mf"))
+            }
+        }
+    }
+
+    @Test func `a project whose models all succeed exits with a zero status`() async throws {
+        await #expect(processExitsWith: .success) {
+            Platform.revealingFilesDisabled = true
+            let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+            await Project(root: directory) {
+                await Model("good") { Box(10) }
+            }
+        }
+    }
+
+    // MARK: - An unwritable destination
+
+    @Test(.enabled(if: readOnlyDirectoriesAreEnforced))
+    func `a model that cannot be written to a read-only directory reports the failure`() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let outcome = await withReadOnlyDirectory(directory) {
+            await BuildFailureBehavior.report.whileCurrent {
+                await Project(root: directory) {
+                    await Model("locked-out") { Box(10) }
+                }
+            }
+        }
+
+        #expect(outcome.succeeded == false)
+        let failure = try #require(outcome.failures.first)
+        #expect(failure.stage == .writing)
+        #expect(failure.modelName == "locked-out")
+        #expect(failure.url?.lastPathComponent == "locked-out.3mf")
+
+        // Nothing at all, not even a partly written file.
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty)
+    }
+
+    // MARK: - Directory creation
+
+    @Test(.enabled(if: readOnlyDirectoriesAreEnforced))
+    func `a project whose output directory cannot be created reports the failure`() async throws {
+        let parent = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let output = parent.appending(path: "output")
+
+        let outcome = await withReadOnlyDirectory(parent) {
+            await BuildFailureBehavior.report.whileCurrent {
+                await Project(root: output) {
+                    await Model("box") { Box(10) }
+                }
+            }
+        }
+
+        #expect(outcome.failures.count == 1)
+        #expect(outcome.failures.first?.stage == .creatingDirectory)
+        #expect(outcome.failures.first?.url == output)
+        #expect(FileManager.default.fileExists(atPath: output.path) == false)
+    }
+
+    @Test(.enabled(if: readOnlyDirectoriesAreEnforced))
+    func `a group whose subdirectory cannot be created reports the failure`() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let outcome = await withReadOnlyDirectory(directory) {
+            await BuildFailureBehavior.report.whileCurrent {
+                await Project(root: directory) {
+                    await Group("parts") {
+                        await Model("box") { Box(10) }
+                    }
+                }
+            }
+        }
+
+        // One failure for the directory, rather than one per model that could not be saved into it.
+        #expect(outcome.failures.count == 1)
+        #expect(outcome.failures.first?.stage == .creatingDirectory)
+        #expect(outcome.failures.first?.modelName == "parts")
+    }
+
+    @Test(.enabled(if: readOnlyDirectoriesAreEnforced))
+    func `a project whose output directory cannot be created exits with a non-zero status`() async throws {
+        await #expect(processExitsWith: .failure) {
+            Platform.revealingFilesDisabled = true
+            let parent = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+            try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+            try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: parent.path)
+            defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: parent.path) }
+
+            await Project(root: parent.appending(path: "output")) {
+                await Model("box") { Box(10) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
`Model.build` logged every evaluation and write error and returned an empty array, and neither `Project` nor the process exit status carried any trace of it. A build script whose models all failed exited 0, which is indistinguishable from success in a Makefile or in CI. Directory creation was `try?`-discarded in both `Project` and `Group`, so a permissions problem surfaced only as a run of later "failed to save" lines, themselves swallowed.

`ModelBuildable.build` now returns a `BuildOutcome` carrying both the created files and every `BuildFailure`. `Group` aggregates its children's, `Project` aggregates the lot, returns it, and ends the process with a non-zero status unless the current `BuildFailureBehavior` says otherwise. Logging goes back to being a courtesy rather than the error channel. Directory creation propagates in both `Project` and `Group`, reported once for the directory rather than once per model that follows it, and the `outputDirectory!` force-unwrap is gone with it.

Twelve tests over the four paths that used to swallow a failure: a project with one failing model, a write into a read-only directory, a directory that cannot be created, and a model that produces no geometry. Exit-status expectations run as exit tests, since the assertion is about the process the build ran in.

**Two things the documentation now says out loud**, because both follow from where the process ends and neither is obvious. A standalone `Model` is its own top-level build, so it ends the program as soon as it fails: a script listing several bare models stops at the first failure, and wrapping them in a `Project` is what builds them all. And a `Group` whose directory cannot be created skips the models inside it, since there is nowhere left to write them. An earlier draft of that section claimed flatly that one failure never stops the rest of the build, which is true only inside a `Project`.

**Two decisions here are worth arguing about rather than assuming**, and they are why this is separate from the atomic-write change it was written alongside.

A library calling `exit()` is the first. It is defensible for `Project`, which is the entry point of a command-line model program, and the `BuildFailureBehavior` task-local exists so an embedding program can opt out. It is more arguable for a standalone `Model`, where it is also what stops a script of several bare models after the first failure. Dropping it there would cost the exit status for the single-model case, which is the common one, so I have documented the behaviour rather than changed it. Happy to go the other way.

An empty `Model {}` counting as a failure is the second. It fires for a legitimately conditional model that built to nothing, which is a reasonable thing to write. It is independent of everything else here and could come out.

Four of the twelve tests are skipped on Windows rather than passed. They all turn on making a directory read-only, and POSIX permission bits do not govern directory writes there, so the directory stays writable and each of those tests would assert the opposite of what happens.

One existing test changes. `Model with no geometry produces no file` in `Build.swift` is renamed to `Model with no geometry produces no file and reports a failure` and scoped to `.report`, since under the default behaviour it would end the test process. It now also asserts which model failed.
