### PR TITLE
Embed a prebuilt binary XCFramework for macOS

### DIFF
--- a/.github/workflows/xcframework.yml
+++ b/.github/workflows/xcframework.yml
@@ -1,0 +1,166 @@
+name: xcframework
+
+# Builds the macOS XCFramework and proves that a package can consume it.
+#
+# On a push or pull request this is a check only. Run the workflow manually with a version to
+# publish: it uploads the artifact to a GitHub release and records that release's checksum in
+# Package.swift.
+
+on:
+  push:
+    branches: [ "main", "dev" ]
+  pull_request:
+    branches: [ "main", "dev" ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, for example 0.11.0. Leave empty to only build and verify."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: xcframework-${{ github.ref }}
+  # A release run must not be cancelled part-way through publishing.
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
+jobs:
+  build:
+    runs-on: macos-26
+
+    outputs:
+      checksum: ${{ steps.checksum.outputs.checksum }}
+
+    steps:
+    - uses: SwiftyLab/setup-swift@latest
+      with:
+        swift-version: '6.3.2'
+    - uses: actions/checkout@v4
+
+    - name: Build the XCFramework
+      run: Scripts/build-xcframework.sh --output .build/xcframework
+
+    - name: Verify the XCFramework
+      run: Scripts/verify-xcframework.sh .build/xcframework/Cadova.xcframework
+
+    - name: Verify that the manifest selects the XCFramework
+      run: Scripts/verify-manifest-selection.sh .build/xcframework/Cadova.xcframework
+
+    # Computed here, where Swift is installed, so the publish job needs no toolchain.
+    - id: checksum
+      run: |
+        set -euo pipefail
+        checksum=$(swift package compute-checksum .build/xcframework/Cadova.xcframework.zip)
+        echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Cadova.xcframework
+        path: .build/xcframework/Cadova.xcframework.zip
+        retention-days: 7
+
+  # The textual interfaces exist for people whose Swift differs from the one that built the
+  # artifact. The build job already compiles them in isolation, but only this consumes the
+  # artifact on a toolchain it was not built with, which is the situation they are for.
+  other-toolchain:
+    needs: build
+    runs-on: macos-26
+
+    steps:
+    - uses: SwiftyLab/setup-swift@latest
+      with:
+        swift-version: 'latest'
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: Cadova.xcframework
+        path: artifact
+
+    - name: Unpack the XCFramework
+      run: unzip -q artifact/Cadova.xcframework.zip -d artifact
+
+    - name: Report the toolchain in use
+      run: swift --version
+
+    - name: Verify the XCFramework
+      run: Scripts/verify-xcframework.sh artifact/Cadova.xcframework
+
+  publish:
+    needs: [build, other-toolchain]
+    if: github.event_name == 'workflow_dispatch' && inputs.version != ''
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: Cadova.xcframework
+        path: artifact
+
+    - name: Publish the release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        VERSION: ${{ inputs.version }}
+        CHECKSUM: ${{ needs.build.outputs.checksum }}
+      run: |
+        set -euo pipefail
+
+        if [[ "$GITHUB_REF_TYPE" != "branch" ]]; then
+          echo "error: run this workflow from a branch, not from $GITHUB_REF_TYPE $GITHUB_REF_NAME" >&2
+          exit 1
+        fi
+        # The version is interpolated into Package.swift below, so it has to be a plain version.
+        if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "error: '$VERSION' is not a version of the form 1.2.3" >&2
+          exit 1
+        fi
+        if [[ ! "$CHECKSUM" =~ ^[0-9a-f]{64}$ ]]; then
+          echo "error: '$CHECKSUM' is not a SHA-256 checksum" >&2
+          exit 1
+        fi
+
+        # The tag has to carry the checksum, so the commit is made and pushed first. The release
+        # creates the tag and uploads the artifact together, so a failure before that point
+        # leaves an ordinary commit on the branch and nothing referring to a missing download.
+        sed -i \
+          -e "s|^let binaryRelease = \".*\"$|let binaryRelease = \"$VERSION\"|" \
+          -e "s|^let binaryChecksum = \".*\"$|let binaryChecksum = \"$CHECKSUM\"|" \
+          Package.swift
+        if git diff --quiet Package.swift; then
+          echo "error: Package.swift was not updated; check the binaryRelease and binaryChecksum lines" >&2
+          exit 1
+        fi
+
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add Package.swift
+        git commit -m "Record the Cadova $VERSION XCFramework in Package.swift"
+        git push origin "HEAD:$GITHUB_REF_NAME"
+
+        gh release create "$VERSION" \
+          --target "$(git rev-parse HEAD)" \
+          --title "Cadova $VERSION" \
+          --generate-notes \
+          artifact/Cadova.xcframework.zip
+
+  # Downloading from the release URL and checking the recorded checksum is the one path that
+  # cannot be tried before the release exists, and the one whose failure blocks every macOS user.
+  verify-release:
+    needs: publish
+    runs-on: macos-26
+
+    steps:
+    - uses: SwiftyLab/setup-swift@latest
+      with:
+        swift-version: '6.3.2'
+    - uses: actions/checkout@v4
+
+    - name: Consume the published release as a new user would
+      run: Scripts/verify-published-release.sh "${{ inputs.version }}" "${{ github.server_url }}/${{ github.repository }}.git"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ xcuserdata/
 /docs-site
 
 /.claude/settings.local.json
+
+__pycache__/

--- a/Package.swift
+++ b/Package.swift
@@ -1,42 +1,125 @@
 // swift-tools-version:6.3
+import Foundation
 import PackageDescription
+
+// MARK: - Binary distribution
+//
+// On macOS, Cadova is distributed as a prebuilt, optimized XCFramework. It removes Cadova and its
+// C/C++ dependencies (Manifold, oneTBB, Clipper2, pugixml, miniz, FreeType, HarfBuzz) from the
+// build entirely, and it is always an optimized release build, so models run at release speed
+// even while you develop in debug. Every other platform builds from source, as before.
+//
+// The binary is used when Cadova is consumed as a dependency. Cadova's own checkout builds from
+// source, so that its tests, its documentation and the XCFramework itself are built from the
+// code in the working tree.
+//
+// Environment overrides:
+//   CADOVA_BUILD_FROM_SOURCE=1        Always build from source.
+//   CADOVA_USE_BINARY=1               Always use the binary, even in Cadova's own checkout.
+//   CADOVA_LOCAL_XCFRAMEWORK=<path>   Use an XCFramework on disk instead of downloading one.
+//                                     SwiftPM requires this path to be relative to this package.
+//
+// The two flags are off when set to 0, no, false or nothing at all, so that setting one to zero
+// does the obvious thing rather than the opposite of it.
+
+// Scripts/build-xcframework.sh prints the checksum, and the xcframework workflow writes both of
+// these lines when it publishes a release. Until a release records a real checksum here, the
+// placeholder makes this manifest fall back to a source build rather than fail to resolve.
+let binaryRelease = "0.10.0"
+let binaryChecksum = "0000000000000000000000000000000000000000000000000000000000000000"
+let binaryURL = "https://github.com/tomasf/Cadova/releases/download/\(binaryRelease)/Cadova.xcframework.zip"
+let hasPublishedBinary = !binaryChecksum.allSatisfy { $0 == "0" }
+
+let environment = ProcessInfo.processInfo.environment
+
+/// Reads one of the flags above. Only a value that means something turns it on; an empty
+/// variable is treated as unset, as are the usual spellings of false.
+func environmentFlag(_ name: String) -> Bool {
+    guard let value = environment[name]?.lowercased() else { return false }
+    return ["", "0", "no", "false"].contains(value) == false
+}
+
+let localXCFramework = environment["CADOVA_LOCAL_XCFRAMEWORK"].flatMap { $0.isEmpty ? nil : $0 }
+
+/// True when this manifest belongs to a checkout that SwiftPM or Xcode made for a dependency,
+/// rather than to a working copy of Cadova itself.
+///
+/// Both put the checkout in a directory named `checkouts`, wherever the enclosing build
+/// directory happens to be, so this holds under `--scratch-path` and under Xcode's
+/// `SourcePackages` too. A package registry downloads to `registry/downloads` instead.
+let isDependencyCheckout: Bool = {
+    let directory = Context.packageDirectory
+    if directory.contains("/registry/downloads/") { return true }
+    return directory.split(separator: "/").dropLast().last == "checkouts"
+}()
+
+let useBinary: Bool = {
+    if environmentFlag("CADOVA_BUILD_FROM_SOURCE") { return false }
+    if localXCFramework != nil { return true }
+    if environmentFlag("CADOVA_USE_BINARY") {
+        guard hasPublishedBinary else {
+            fatalError("CADOVA_USE_BINARY is set, but no XCFramework has been published for this "
+                       + "version of Cadova. Unset it, or set CADOVA_LOCAL_XCFRAMEWORK to a "
+                       + "path relative to this package.")
+        }
+        return true
+    }
+    #if os(macOS)
+    return isDependencyCheckout && hasPublishedBinary
+    #else
+    return false
+    #endif
+}()
+
+// MARK: - Targets
+
+let sourceDependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/tomasf/manifold-swift.git", .upToNextMinor(from: "1.1.1")),
+    .package(url: "https://github.com/tomasf/ThreeMF.git", .upToNextMinor(from: "0.3.0")),
+    .package(url: "https://github.com/tomasf/Apus.git", .upToNextMinor(from: "0.1.4")),
+    .package(url: "https://github.com/tomasf/Pelagos.git", .upToNextMinor(from: "0.1.4")),
+    .package(url: "https://github.com/tomasf/CadovaLiveLink.git", .upToNextMinor(from: "0.2.1")),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.0"),
+]
+
+let cadovaTarget: Target = if useBinary, let path = localXCFramework {
+    .binaryTarget(name: "Cadova", path: path)
+} else if useBinary {
+    .binaryTarget(name: "Cadova", url: binaryURL, checksum: binaryChecksum)
+} else {
+    .target(
+        name: "Cadova",
+        dependencies: [
+            .product(name: "Apus", package: "Apus"),
+            .product(name: "Manifold", package: "manifold-swift"),
+            .product(name: "ThreeMF", package: "ThreeMF"),
+            .product(name: "Pelagos", package: "Pelagos"),
+            .product(name: "CadovaLiveLinkClient", package: "CadovaLiveLink", condition: .when(platforms: [.macOS])),
+        ],
+        swiftSettings: [ .interoperabilityMode(.Cxx) ]
+    )
+}
+
+let testTarget: Target = .testTarget(
+    name: "Tests",
+    dependencies: [
+        "Cadova",
+        .product(name: "ThreeMF", package: "ThreeMF"),
+        .product(name: "CadovaLiveLinkClient", package: "CadovaLiveLink", condition: .when(platforms: [.macOS])),
+    ],
+    resources: [.copy("golden"), .copy("resources")],
+    swiftSettings: [ .interoperabilityMode(.Cxx) ]
+)
 
 let package = Package(
     name: "Cadova",
     platforms: [.macOS(.v14)],
-    products: [
-        .library(name: "Cadova", targets: ["Cadova"]),
-    ],
-    dependencies: [
-        .package(url: "https://github.com/tomasf/manifold-swift.git", .upToNextMinor(from: "1.1.1")),
-        .package(url: "https://github.com/tomasf/ThreeMF.git", .upToNextMinor(from: "0.3.0")),
-        .package(url: "https://github.com/tomasf/Apus.git", .upToNextMinor(from: "0.1.4")),
-        .package(url: "https://github.com/tomasf/Pelagos.git", .upToNextMinor(from: "0.1.4")),
-        .package(url: "https://github.com/tomasf/CadovaLiveLink.git", .upToNextMinor(from: "0.2.1")),
-        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.0"),
-    ],
-    targets: [
-        .target(
-            name: "Cadova",
-            dependencies: [
-                .product(name: "Apus", package: "Apus"),
-                .product(name: "Manifold", package: "manifold-swift"),
-                .product(name: "ThreeMF", package: "ThreeMF"),
-                .product(name: "Pelagos", package: "Pelagos"),
-                .product(name: "CadovaLiveLinkClient", package: "CadovaLiveLink", condition: .when(platforms: [.macOS])),
-            ],
-            swiftSettings: [ .interoperabilityMode(.Cxx) ]
-        ),
-        .testTarget(
-            name: "Tests",
-            dependencies: [
-                "Cadova",
-                .product(name: "ThreeMF", package: "ThreeMF"),
-                .product(name: "CadovaLiveLinkClient", package: "CadovaLiveLink", condition: .when(platforms: [.macOS])),
-            ],
-            resources: [.copy("golden"), .copy("resources")],
-            swiftSettings: [ .interoperabilityMode(.Cxx) ]
-        )
-    ],
+    products: [.library(name: "Cadova", targets: ["Cadova"])] + (useBinary ? [] : [
+        // Cadova and all of its dependencies as a single static archive. This is what
+        // Scripts/build-xcframework.sh packages; it is not meant to be depended on directly.
+        .library(name: "CadovaStatic", type: .static, targets: ["Cadova"]),
+    ]),
+    dependencies: useBinary ? [] : sourceDependencies,
+    targets: useBinary ? [cadovaTarget] : [cadovaTarget, testTarget],
     cxxLanguageStandard: .cxx17
 )

--- a/README.md
+++ b/README.md
@@ -45,6 +45,34 @@ Cadova uses [Manifold-Swift](https://github.com/tomasf/manifold-swift), [Apus](h
 
 Cadova is currently in pre-release, with a version number below 1.0. The API is still evolving, but stability is maintained within each minor version — so `upToNextMinor(from:)` is recommended for your dependency. You're very welcome to start using Cadova today, and feedback is appreciated!
 
+## Prebuilt binary on macOS
+
+On macOS, Cadova resolves to a prebuilt XCFramework instead of building from source. Nothing in your manifest changes; you depend on Cadova exactly as shown above and get the binary automatically. It removes Cadova and its nine C and C++ targets from your build, and because the binary is always an optimized release build, your models run at release speed even while you build in debug.
+
+Measured on a boolean-heavy model, building it clean and running it once:
+
+| | From source | From the binary |
+| --- | --- | --- |
+| Clean debug build, wall clock | 75 s | 35 s |
+| Clean debug build, CPU time | 271 s | 27 s |
+| Running the model from a debug build | 1.63 s | 0.27 s |
+
+The CPU figure is the one to watch on a laptop or a CI runner with few cores, where wall clock follows CPU time far more closely than on a many-core machine. Heavier models gain more at run time than the 6x above. The download is about 10 MB.
+
+Linux and Windows build from source, as before.
+
+The XCFramework carries its own copies of Manifold, ThreeMF, Nodal, Zip, Apus and Pelagos, but keeps them private, so you can still depend on any of those packages yourself and get your own copy. The one module it shares with you is `Manifold3D`, because Cadova's own API is written in terms of it: `import Manifold3D` works without declaring `manifold-swift`, and declaring it anyway gives you two copies of the same module.
+
+To build from source on macOS too, set `CADOVA_BUILD_FROM_SOURCE=1` in the environment when you build. Cadova's own checkout always builds from source, so working on Cadova itself needs no extra setup.
+
+To produce the artifact yourself:
+
+```bash
+Scripts/build-xcframework.sh
+Scripts/verify-xcframework.sh .build/xcframework/Cadova.xcframework
+Scripts/verify-manifest-selection.sh .build/xcframework/Cadova.xcframework
+```
+
 ## Contributions
 Contributions are welcome! If you have ideas, suggestions, or improvements, feel free to open an issue or submit a pull request. You’re also welcome to browse the [open GitHub issues](https://github.com/tomasf/Cadova/issues) and pick one to work on — especially those marked as good first issues or help wanted.
 

--- a/Scripts/build-xcframework.sh
+++ b/Scripts/build-xcframework.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+#
+# Builds Cadova.xcframework: an optimized, universal (arm64 + x86_64) macOS static library that
+# bundles Cadova together with every Swift and C/C++ dependency it needs, plus textual module
+# interfaces so it can be imported by any compatible Swift compiler.
+#
+# Why this works where the obvious approach does not: Swift cannot currently export a C or C++
+# target from a binary package, and Cadova depends on several (Manifold, oneTBB, Clipper2,
+# pugixml, miniz, FreeType, HarfBuzz). None of them appear in Cadova's public API, though. They
+# are imported with `internal import`, so they never reach a module interface; they only need to
+# be present as object code, which a static library provides.
+#
+# Bundling them creates a second problem. A package that depends on both Cadova and, say,
+# ThreeMF would link two copies of ThreeMF and fail with hundreds of duplicate symbols. So the
+# archive is relinked into a single object with every symbol that does not belong to an exported
+# module made private. What a client can see, and therefore collide with, is exactly the set of
+# modules the XCFramework exports.
+#
+# Usage: Scripts/build-xcframework.sh [--output <dir>] [--scratch-path <dir>]
+#
+# Writes <output>/Cadova.xcframework and <output>/Cadova.xcframework.zip, and prints the
+# checksum that a consuming Package.swift needs for the zip.
+
+set -euo pipefail
+
+package_root=$(cd "$(dirname "$0")/.." && pwd)
+output_dir="$package_root/.build/xcframework"
+scratch_path="$package_root/.build/xcframework-scratch"
+triples=(arm64-apple-macosx x86_64-apple-macosx)
+deployment_target=14.0
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --output) output_dir=$2; shift 2 ;;
+        --scratch-path) scratch_path=$2; shift 2 ;;
+        *) echo "Usage: $0 [--output <dir>] [--scratch-path <dir>]" >&2; exit 64 ;;
+    esac
+done
+
+mkdir -p "$output_dir" "$scratch_path"
+output_dir=$(cd "$output_dir" && pwd)
+scratch_path=$(cd "$scratch_path" && pwd)
+staging_dir="$scratch_path/staging"
+xcframework="$output_dir/Cadova.xcframework"
+sdk=$(xcrun --sdk macosx --show-sdk-path)
+
+build_dir() {
+    echo "$scratch_path/$1/release"
+}
+
+# Cadova and every package module reachable through the imports of its interface. Those are the
+# modules a client needs to see; everything else is an implementation detail that stays inside
+# the static library, with its symbols hidden.
+exposed_modules() {
+    local dir=$1
+    local queue="Cadova" result="" module dependency
+
+    while [[ -n $queue ]]; do
+        module=${queue%% *}
+        queue=${queue#"$module"}
+        queue=${queue# }
+        case " $result " in *" $module "*) continue ;; esac
+        result="$result $module"
+
+        for dependency in $(sed -n -E 's/^([a-z_]+ )?import ([A-Za-z0-9_]+).*$/\2/p' \
+                "$dir/$module.build/$module.swiftinterface"); do
+            if [[ -f "$dir/Modules/$dependency.swiftmodule" ]]; then
+                queue="$queue $dependency"
+            fi
+        done
+    done
+    echo "${result# }"
+}
+
+# Copies one file per exported module and architecture into the staging tree.
+stage_module_files() {
+    local source_subdirectory=$1 extension=$2 triple dir arch module bundle
+    for triple in "${triples[@]}"; do
+        dir=$(build_dir "$triple")
+        arch=${triple%%-*}
+        for module in $modules; do
+            bundle="$staging_dir/Headers/$module.swiftmodule"
+            mkdir -p "$bundle"
+            cp "$dir/${source_subdirectory//MODULE/$module}/$module.$extension" \
+               "$bundle/$arch-apple-macos.$extension"
+        done
+    done
+}
+
+# Library evolution is what makes a module interface possible, and SwiftPM applies -Xswiftc to
+# every target, so the internal modules are built resilient as well even though nothing reads
+# their interfaces. Resilience costs a little speed at module boundaries, so this was measured on
+# a boolean-heavy model: 0.220 s median without it against 0.224 s with it, over five runs each,
+# with the two ranges overlapping. Cadova's hot path is Manifold's C++, which resilience does not
+# touch, so the difference is not worth a more complicated build.
+for triple in "${triples[@]}"; do
+    echo "==> Building Cadova for $triple"
+    # Cadova's own manifest must not pull in the binary it is about to produce.
+    CADOVA_BUILD_FROM_SOURCE=1 swift build \
+        --package-path "$package_root" \
+        --scratch-path "$scratch_path" \
+        --configuration release \
+        --product CadovaStatic \
+        --triple "$triple" \
+        -Xswiftc -enable-library-evolution \
+        -Xswiftc -emit-module-interface \
+        -Xswiftc -no-verify-emitted-module-interface
+done
+
+rm -rf "$staging_dir" "$xcframework" "$xcframework.zip"
+mkdir -p "$staging_dir/Headers"
+
+modules=$(exposed_modules "$(build_dir "${triples[0]}")")
+echo "==> Exporting modules: $modules"
+
+# Record what this artifact is and where it came from. A binary that cannot say which source it
+# was built from is hard to support, because a bug report names a Cadova version but the version
+# alone does not identify the build. verify-xcframework.sh also reads the module list from here
+# rather than restating it.
+echo "==> Recording build info"
+CADOVA_MODULES="$modules" \
+CADOVA_ARCHITECTURES="${triples[*]%%-*}" \
+CADOVA_DEPLOYMENT_TARGET="$deployment_target" \
+CADOVA_COMMIT="$(git -C "$package_root" rev-parse HEAD 2>/dev/null || echo unknown)" \
+CADOVA_TREE="$(test -z "$(git -C "$package_root" status --porcelain 2>/dev/null)" && echo clean || echo dirty)" \
+CADOVA_SWIFT="$(swift --version 2>&1 | head -1)" \
+python3 -c '
+import json, os, datetime
+info = {
+    "exportedModules": os.environ["CADOVA_MODULES"].split(),
+    "architectures": os.environ["CADOVA_ARCHITECTURES"].split(),
+    "deploymentTarget": os.environ["CADOVA_DEPLOYMENT_TARGET"],
+    "commit": os.environ["CADOVA_COMMIT"],
+    "workingTree": os.environ["CADOVA_TREE"],
+    "swift": os.environ["CADOVA_SWIFT"],
+    "builtAt": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+}
+print(json.dumps(info, indent=2))
+' > "$staging_dir/Headers/cadova-build-info.json"
+python3 -c '
+import json, sys
+info = json.load(open(sys.argv[1]))
+print("    commit %s (%s tree)" % (info["commit"], info["workingTree"]))
+' "$staging_dir/Headers/cadova-build-info.json"
+
+stage_module_files "MODULE.build" swiftinterface
+
+# Repairs a Swift interface printer bug and, either way, proves that every exported interface
+# type-checks the way a client importing it would. See the script for details. This runs before
+# the binary modules are staged, so it exercises the interface-only path that a client on a
+# different Swift version falls back to.
+module_arguments=()
+for module in $modules; do
+    module_arguments+=(--module "$module")
+done
+"$package_root/Scripts/repair-module-interface.py" \
+    --headers "$staging_dir/Headers" \
+    --sdk "$sdk" \
+    "${module_arguments[@]}"
+
+# A client on this exact Swift version loads these instead of parsing the interfaces.
+stage_module_files Modules swiftmodule
+stage_module_files Modules swiftdoc
+
+# Relinks one architecture's archive into a single object, keeping only the symbols the exported
+# modules define. Everything else becomes private to the object, so a client that also depends
+# on ThreeMF, Nodal, Zip, Apus or Pelagos links its own copy without colliding with ours.
+hide_internal_symbols() {
+    local triple=$1
+    local dir; dir=$(build_dir "$triple")
+    local arch=${triple%%-*}
+    local work="$scratch_path/hidden/$arch"
+    local module objects=()
+
+    rm -rf "$work"
+    mkdir -p "$work"
+
+    for module in $modules; do
+        while IFS= read -r object; do objects+=("$object"); done \
+            < <(find "$dir/$module.build" -name "*.o")
+    done
+    nm -gjU "${objects[@]}" | sort -u > "$work/exported.syms"
+    nm -gjU "$dir/libCadovaStatic.a" | sort -u > "$work/all.syms"
+    comm -23 "$work/all.syms" "$work/exported.syms" > "$work/hidden.syms"
+    echo "    $arch: hiding $(wc -l < "$work/hidden.syms" | tr -d ' ') internal symbols"
+
+    ld -r -all_load "$dir/libCadovaStatic.a" \
+        -unexported_symbols_list "$work/hidden.syms" \
+        -arch "$arch" \
+        -platform_version macos "$deployment_target" "$deployment_target" \
+        -o "$work/Cadova.o"
+
+    # Most of the merged object is a symbol table naming the internals that were just made
+    # private, which no client can refer to. Dropping it, and the debug symbols with it, halves
+    # what people download. Swift metadata and Objective-C class registration live in their own
+    # sections and are untouched.
+    strip -S -x "$work/Cadova.o"
+
+    libtool -static -o "$work/libCadova.a" "$work/Cadova.o"
+}
+
+echo "==> Hiding internal symbols"
+libraries=()
+for triple in "${triples[@]}"; do
+    hide_internal_symbols "$triple"
+    libraries+=("$scratch_path/hidden/${triple%%-*}/libCadova.a")
+done
+
+echo "==> Creating universal static library"
+lipo -create "${libraries[@]}" -output "$staging_dir/libCadova.a"
+
+echo "==> Creating $xcframework"
+xcodebuild -create-xcframework \
+    -library "$staging_dir/libCadova.a" \
+    -headers "$staging_dir/Headers" \
+    -output "$xcframework"
+
+echo "==> Creating $xcframework.zip"
+ditto -c -k --keepParent "$xcframework" "$xcframework.zip"
+
+checksum=$(swift package --package-path "$package_root" compute-checksum "$xcframework.zip")
+echo "==> Done"
+echo "xcframework: $xcframework"
+echo "zip:         $xcframework.zip"
+echo "checksum:    $checksum"

--- a/Scripts/repair-module-interface.py
+++ b/Scripts/repair-module-interface.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Repairs and verifies the textual Swift module interfaces that go into Cadova.xcframework.
+
+Swift's module interface printer emits a redundant associated type witness for every type that
+conforms to a *parameterized* protocol, for example
+
+    public struct Arc : Cadova.Geometry2D {   // Geometry2D == Geometry<D2>, which already binds D
+      public typealias D = Cadova.D2          // ... so this second binding is ambiguous
+    }
+
+The conformance clause already binds the associated type, so the printed typealias is a second,
+competing witness and the interface fails to compile with "multiple matching types named 'D'".
+The same declaration written by hand is rejected by the compiler, so this is a printer bug and
+not something Cadova's sources can express differently.
+
+This script uses the compiler itself as the oracle: it type-checks each interface, collects the
+witnesses the compiler reports as ambiguous, deletes exactly those lines, and type-checks again.
+A toolchain without the bug reports nothing, so nothing is deleted. Verification of the final
+interface is unconditional, so a repair that does not fully work fails the build rather than
+shipping a broken interface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# "Cadova.swiftinterface:25:18: note: multiple matching types named 'D'" names the requirement
+# the compiler could not resolve; the "possibly intended match" notes that follow name each
+# competing witness. Only a witness reported under an ambiguity is ever removed.
+AMBIGUITY_PATTERN = re.compile(r"^.+:\d+:\d+: note: multiple matching types named ")
+MATCH_PATTERN = re.compile(r"^(?P<path>.+):(?P<line>\d+):\d+: note: possibly intended match$")
+# Only ever delete a line that is exactly a redundant associated type witness.
+WITNESS_PATTERN = re.compile(r"^\s*public typealias [A-Za-z_][A-Za-z0-9_]* = [^{}]+$")
+
+# One pass removes every witness the compiler reports, so a second is only needed if removing
+# some unmasks others. Three is generous; the loop stops as soon as an interface type-checks.
+MAX_PASSES = 3
+
+
+class TypeCheckFailed(Exception):
+    """The compiler could not be run, or failed without saying why."""
+
+
+def type_check(interface: Path, module_name: str, sdk: str, search_path: Path) -> str:
+    """Type-checks an interface exactly as a client importing it would.
+
+    Returns the diagnostics, or an empty string when the interface is good. A failure the
+    compiler did not explain is an error in its own right, never a silent pass.
+    """
+    result = subprocess.run(
+        [
+            "xcrun", "swift-frontend",
+            "-typecheck-module-from-interface", str(interface),
+            "-module-name", module_name,
+            "-sdk", sdk,
+            "-I", str(search_path),
+            "-diagnostic-style", "llvm",
+        ],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        return ""
+    diagnostics = result.stdout + result.stderr
+    if not diagnostics.strip():
+        raise TypeCheckFailed(
+            f"swift-frontend exited with {result.returncode} and no diagnostics "
+            f"while type-checking {interface}"
+        )
+    return diagnostics
+
+
+def ambiguous_witness_lines(diagnostics: str, interface: Path) -> set[int]:
+    """The lines in `interface` reported as competing witnesses for an ambiguous requirement."""
+    lines: set[int] = set()
+    under_ambiguity = False
+    for diagnostic in diagnostics.splitlines():
+        if AMBIGUITY_PATTERN.match(diagnostic):
+            under_ambiguity = True
+            continue
+        match = MATCH_PATTERN.match(diagnostic)
+        if not match:
+            # Any other diagnostic line ends the run of notes belonging to one ambiguity.
+            if diagnostic.endswith(":") or ": note: " in diagnostic or ": error: " in diagnostic:
+                under_ambiguity = False
+            continue
+        if under_ambiguity and Path(match.group("path")).resolve() == interface.resolve():
+            lines.add(int(match.group("line")))
+    return lines
+
+
+def repair(interface: Path, module_name: str, sdk: str, search_path: Path) -> None:
+    diagnostics = type_check(interface, module_name, sdk, search_path)
+
+    for _ in range(MAX_PASSES):
+        if not diagnostics:
+            return
+
+        reported = ambiguous_witness_lines(diagnostics, interface)
+        source_lines = interface.read_text().splitlines(keepends=True)
+        removable = {
+            line for line in reported
+            if 1 <= line <= len(source_lines)
+            and WITNESS_PATTERN.match(source_lines[line - 1].rstrip("\n"))
+        }
+        if not removable:
+            break
+
+        kept = [text for number, text in enumerate(source_lines, start=1) if number not in removable]
+        interface.write_text("".join(kept))
+        print(f"    removed {len(removable)} redundant associated type witness(es) "
+              f"from {interface.name}")
+        diagnostics = type_check(interface, module_name, sdk, search_path)
+
+    if diagnostics:
+        raise TypeCheckFailed(
+            f"{interface} does not type-check as a client would see it:\n{diagnostics}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--headers", required=True, type=Path,
+                        help="staging directory holding the <Module>.swiftmodule interface bundles")
+    parser.add_argument("--sdk", required=True, help="macOS SDK to type-check against")
+    parser.add_argument("--module", action="append", default=[], required=True,
+                        help="a module to repair and verify; repeat for each module")
+    arguments = parser.parse_args()
+
+    for module_name in arguments.module:
+        bundle = arguments.headers / f"{module_name}.swiftmodule"
+        interfaces = sorted(bundle.glob("*.swiftinterface"))
+        if not interfaces:
+            print(f"error: no interface for module {module_name} in {bundle}", file=sys.stderr)
+            sys.exit(1)
+        for interface in interfaces:
+            print(f"==> Verifying {module_name} ({interface.stem})")
+            try:
+                repair(interface, module_name, arguments.sdk, arguments.headers)
+            except TypeCheckFailed as failure:
+                print(f"error: {failure}", file=sys.stderr)
+                sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/verify-manifest-selection.sh
+++ b/Scripts/verify-manifest-selection.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Checks that Package.swift picks the binary or a source build in the situations that matter.
+#
+# The choice is made from the environment and from where the package sits on disk, so nothing
+# about it shows up in an ordinary build of Cadova. This exercises it directly: it copies the
+# manifest into a directory shaped like a dependency checkout and asks SwiftPM what it decided.
+#
+# Usage: Scripts/verify-manifest-selection.sh <path/to/Cadova.xcframework>
+
+set -euo pipefail
+
+fail() {
+    echo "error: $1" >&2
+    exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <path/to/Cadova.xcframework>" >&2
+    exit 64
+fi
+
+[[ -d $1 ]] || fail "$1 is not a directory"
+xcframework=$(cd "$1" && pwd)
+package_root=$(cd "$(dirname "$0")/.." && pwd)
+
+workdir=$(mktemp -d -t cadova-manifest-selection)
+trap 'rm -rf "$workdir"' EXIT
+
+# The kind of the Cadova target is the decision: "binary" means the XCFramework was chosen,
+# "regular" means a source build.
+cadova_target_kind() {
+    local dir=$1
+    swift package --package-path "$dir" dump-package \
+        | python3 -c 'import json,sys; print(next(t["type"] for t in json.load(sys.stdin)["targets"] if t["name"] == "Cadova"))'
+}
+
+expect_kind() {
+    local dir=$1 expected=$2 description=$3 actual
+    actual=$(cadova_target_kind "$dir")
+    [[ $actual == "$expected" ]] || fail "$description: Cadova is a '$actual' target, expected '$expected'"
+    echo "    $description -> $actual"
+}
+
+echo "==> Checking the manifest in Cadova's own checkout"
+expect_kind "$package_root" regular "a working copy builds from source"
+CADOVA_BUILD_FROM_SOURCE=1 expect_kind "$package_root" regular "CADOVA_BUILD_FROM_SOURCE forces source"
+
+echo "==> Checking the manifest in a dependency checkout"
+# SwiftPM and Xcode both place a resolved dependency in a directory named "checkouts", which is
+# what the manifest looks for. Only the manifest matters here, so the sources are not copied.
+checkout="$workdir/some-scratch-path/checkouts/Cadova"
+mkdir -p "$checkout/Sources/Cadova"
+cp "$package_root/Package.swift" "$checkout/Package.swift"
+touch "$checkout/Sources/Cadova/Placeholder.swift"
+ditto "$xcframework" "$checkout/Cadova.xcframework"
+
+# Until a release records a real checksum, a dependency checkout has to fall back to source
+# rather than resolve a download that does not exist.
+if grep -q '^let binaryChecksum = "0*"$' "$checkout/Package.swift"; then
+    expect_kind "$checkout" regular "an unpublished checksum falls back to source"
+else
+    expect_kind "$checkout" binary "a published checksum selects the binary"
+fi
+
+# With an XCFramework on disk the choice must not depend on a published release at all.
+CADOVA_LOCAL_XCFRAMEWORK=Cadova.xcframework \
+    expect_kind "$checkout" binary "CADOVA_LOCAL_XCFRAMEWORK selects the binary"
+CADOVA_LOCAL_XCFRAMEWORK=Cadova.xcframework CADOVA_BUILD_FROM_SOURCE=1 \
+    expect_kind "$checkout" regular "CADOVA_BUILD_FROM_SOURCE wins over a local XCFramework"
+
+# Setting a flag to zero has to turn it off. Testing only that the variable exists would make
+# CADOVA_BUILD_FROM_SOURCE=0 force a source build, which is the opposite of what it says.
+echo "==> Checking that a flag set to zero is off"
+CADOVA_LOCAL_XCFRAMEWORK=Cadova.xcframework CADOVA_BUILD_FROM_SOURCE=0 \
+    expect_kind "$checkout" binary "CADOVA_BUILD_FROM_SOURCE=0 leaves the binary alone"
+CADOVA_LOCAL_XCFRAMEWORK=Cadova.xcframework CADOVA_BUILD_FROM_SOURCE= \
+    expect_kind "$checkout" binary "an empty CADOVA_BUILD_FROM_SOURCE counts as unset"
+CADOVA_USE_BINARY=0 expect_kind "$package_root" regular "CADOVA_USE_BINARY=0 does not force the binary"
+
+echo "==> Manifest selection verified"

--- a/Scripts/verify-published-release.sh
+++ b/Scripts/verify-published-release.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+# Checks a published Cadova release the way a new user meets it: declare the package, let SwiftPM
+# download the XCFramework from the release URL, verify its checksum, and build and run a model.
+#
+# Everything else in this repository tests an artifact on disk. Only this exercises the download
+# URL and the checksum recorded in the released Package.swift, which is the one path that cannot
+# be tried before a release exists and the one whose failure blocks every macOS user at once.
+#
+# Usage: Scripts/verify-published-release.sh <version> [repository-url]
+
+set -euo pipefail
+
+fail() {
+    echo "error: $1" >&2
+    exit 1
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: $0 <version> [repository-url]" >&2
+    exit 64
+fi
+
+version=$1
+repository=${2:-https://github.com/tomasf/Cadova.git}
+
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "'$version' is not a version of the form 1.2.3"
+
+workdir=$(mktemp -d -t cadova-published-release)
+trap 'rm -rf "$workdir"' EXIT
+
+package_dir="$workdir/Consumer"
+mkdir -p "$package_dir/Sources/Consumer"
+
+cat > "$package_dir/Package.swift" <<PACKAGE
+// swift-tools-version:6.3
+import PackageDescription
+
+let package = Package(
+    name: "Consumer",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(url: "$repository", exact: "$version"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "Consumer",
+            dependencies: [.product(name: "Cadova", package: "Cadova")],
+            swiftSettings: [.interoperabilityMode(.Cxx)]
+        ),
+    ]
+)
+PACKAGE
+
+cat > "$package_dir/Sources/Consumer/main.swift" <<'SOURCE'
+import Cadova
+import Foundation
+
+await Model(CommandLine.arguments[1]) {
+    Box(x: 20, y: 20, z: 5)
+        .subtracting {
+            Sphere(diameter: 12).translated(x: 10, y: 10, z: 5)
+        }
+}
+SOURCE
+
+echo "==> Resolving Cadova $version from $repository"
+swift package --package-path "$package_dir" resolve
+
+# A source build here would mean the manifest declined the binary, which defeats the point of
+# publishing one, so check what it actually chose before trusting the run below.
+target_kind=$(swift package --package-path "$package_dir" dump-package \
+    | python3 -c 'import json,sys; print(next((t["type"] for t in json.load(sys.stdin)["targets"] if t["name"] == "Consumer"), "missing"))')
+[[ $target_kind == regular ]] || fail "the consumer target came out as '$target_kind'"
+
+checkout=$(find "$package_dir/.build" -type d -name Cadova -path "*checkouts*" -print -quit)
+[[ -n $checkout ]] || fail "Cadova was not checked out"
+cadova_kind=$(swift package --package-path "$checkout" dump-package \
+    | python3 -c 'import json,sys; print(next(t["type"] for t in json.load(sys.stdin)["targets"] if t["name"] == "Cadova"))')
+[[ $cadova_kind == binary ]] || fail "Cadova $version resolved to a '$cadova_kind' target, so the published binary was not used"
+echo "    Cadova resolved to a binary target"
+
+echo "==> Building and running a model against the published binary"
+swift build --package-path "$package_dir" -c debug
+output="$workdir/output"
+swift run --package-path "$package_dir" -c debug --skip-build Consumer "$output"
+
+[[ -s "$output.3mf" ]] || fail "no $output.3mf was written"
+listing=$(unzip -l "$output.3mf")
+grep -q "3D/3dmodel.model" <<<"$listing" || fail "$output.3mf is not a valid 3MF container"
+echo "    wrote $(stat -f %z "$output.3mf") bytes of valid 3MF"
+
+echo "==> Cadova $version verified as published"

--- a/Scripts/verify-xcframework.sh
+++ b/Scripts/verify-xcframework.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+#
+# Verifies a prebuilt Cadova.xcframework by consuming it exactly as a package user would.
+#
+# It checks the shape of the artifact, then builds and runs a model that exercises every bundled
+# dependency: Manifold booleans, Apus/FreeType/HarfBuzz text, Pelagos/Nodal SVG import and
+# ThreeMF/miniz 3MF output. Both debug and release configurations are covered, because a static
+# library built for release still has to link into a debug client. A second package additionally
+# depends on ThreeMF directly, which is what proves that the dependencies bundled into the
+# artifact stay private and do not collide with a client's own copy.
+#
+# Usage: Scripts/verify-xcframework.sh <path/to/Cadova.xcframework>
+
+set -euo pipefail
+
+fail() {
+    echo "error: $1" >&2
+    exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <path/to/Cadova.xcframework>" >&2
+    exit 64
+fi
+
+[[ -d $1 ]] || fail "$1 is not a directory"
+xcframework=$(cd "$1" && pwd)
+[[ -f "$xcframework/Info.plist" ]] || fail "$xcframework is not an XCFramework"
+
+# MARK: - Shape of the artifact
+
+echo "==> Checking architectures"
+library=$(find "$xcframework" -name "libCadova.a" -print -quit)
+[[ -n $library ]] || fail "no libCadova.a inside $xcframework"
+architectures=$(lipo -info "$library")
+for arch in arm64 x86_64; do
+    grep -qw "$arch" <<<"$architectures" || fail "$library has no $arch slice"
+done
+echo "    $architectures"
+
+echo "==> Checking build info"
+headers=$(dirname "$library")/Headers
+[[ -d $headers ]] || fail "no Headers directory next to $library"
+build_info="$headers/cadova-build-info.json"
+[[ -f $build_info ]] || fail "no cadova-build-info.json in $headers"
+
+# Reading one field at a time keeps a malformed file from failing silently.
+build_info_field() {
+    python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' "$build_info" "$1" \
+        || fail "cadova-build-info.json has no usable '$1'"
+}
+echo "    built from $(build_info_field commit) ($(build_info_field workingTree) tree)"
+echo "    $(build_info_field swift)"
+echo "    at $(build_info_field builtAt)"
+
+echo "==> Checking exported modules"
+# The build script records the set it computed; the artifact must match it exactly. Anything
+# else means a module was added or lost without anyone noticing.
+expected_modules=$(python3 -c \
+    'import json,sys; print("\n".join(sorted(json.load(open(sys.argv[1]))["exportedModules"])))' \
+    "$build_info")
+actual_modules=$(cd "$headers" && for bundle in *.swiftmodule; do echo "${bundle%.swiftmodule}"; done | sort)
+if [[ "$actual_modules" != "$expected_modules" ]]; then
+    fail "exported modules are '$(tr '\n' ' ' <<<"$actual_modules")', expected '$(tr '\n' ' ' <<<"$expected_modules")'"
+fi
+echo "    $(tr '\n' ' ' <<<"$actual_modules")"
+
+# MARK: - Consuming the artifact
+
+workdir=$(mktemp -d -t cadova-xcframework-verify)
+trap 'rm -rf "$workdir"' EXIT
+
+# Writes a throwaway package that links the artifact. $1 is its directory, $2 an extra dependency
+# clause for Package.swift and $3 the matching target dependency, both of which may be empty.
+write_package() {
+    local dir=$1 package_dependency=$2 target_dependency=$3
+    mkdir -p "$dir/Sources/SmokeTest"
+
+    # SwiftPM only accepts a binary target path relative to the package root, so the artifact is
+    # copied in. That also proves it does not depend on where it was built.
+    ditto "$xcframework" "$dir/Cadova.xcframework"
+
+    cat > "$dir/Package.swift" <<PACKAGE
+// swift-tools-version:6.3
+import PackageDescription
+
+let package = Package(
+    name: "SmokeTest",
+    platforms: [.macOS(.v14)],
+    dependencies: [$package_dependency],
+    targets: [
+        .binaryTarget(name: "Cadova", path: "Cadova.xcframework"),
+        .executableTarget(
+            name: "SmokeTest",
+            dependencies: ["Cadova"$target_dependency],
+            swiftSettings: [.interoperabilityMode(.Cxx)]
+        ),
+    ]
+)
+PACKAGE
+}
+
+cat > "$workdir/model.swift" <<'SOURCE'
+import Cadova
+import Foundation
+
+// Every import above has to resolve out of the XCFramework alone.
+let outputBase = CommandLine.arguments[1]
+
+let svg = """
+<svg xmlns="http://www.w3.org/2000/svg" width="10mm" height="10mm" viewBox="0 0 10 10">
+  <circle cx="5" cy="5" r="4"/>
+</svg>
+"""
+
+await Model(outputBase) {
+    // Manifold: a boolean over an extruded profile.
+    Box(x: 60, y: 16, z: 4)
+        .subtracting {
+            // Apus, FreeType and HarfBuzz: shaping and glyph outlines.
+            Text("Cadova")
+                .extruded(height: 4)
+                .translated(x: 3, y: 3, z: 1)
+            // Pelagos and Nodal: parsing and flattening an SVG document.
+            Import(svg: Data(svg.utf8))
+                .extruded(height: 4)
+                .translated(x: 45, y: 3, z: 1)
+        }
+}
+SOURCE
+
+# Builds and runs one package, then checks that it wrote a real 3MF. ThreeMF and miniz produce a
+# zip container holding a 3D model part, so an unreadable archive means the bundled code is
+# broken even though the process exited cleanly.
+build_and_run() {
+    local dir=$1 configuration=$2 label=$3 output listing
+    echo "==> Building $label ($configuration)"
+    swift build --package-path "$dir" -c "$configuration"
+
+    output="$dir/output-$configuration"
+    echo "==> Running $label ($configuration)"
+    swift run --package-path "$dir" -c "$configuration" --skip-build SmokeTest "$output"
+
+    [[ -s "$output.3mf" ]] || fail "$label ($configuration) produced no $output.3mf"
+    listing=$(unzip -l "$output.3mf")
+    grep -q "3D/3dmodel.model" <<<"$listing" || fail "$output.3mf is not a valid 3MF container"
+    echo "    wrote $(stat -f %z "$output.3mf") bytes of valid 3MF"
+}
+
+write_package "$workdir/SmokeTest" "" ""
+cp "$workdir/model.swift" "$workdir/SmokeTest/Sources/SmokeTest/main.swift"
+for configuration in debug release; do
+    build_and_run "$workdir/SmokeTest" "$configuration" "the smoke test"
+done
+
+# A client whose Swift version does not match the one that built the artifact cannot load the
+# binary modules and compiles the textual interfaces instead. Deleting the binary modules from a
+# copy forces that path here, on whatever toolchain is running, rather than leaving it to be
+# discovered by the first person on a different Xcode.
+echo "==> Checking the interface-only path a mismatched Swift version falls back to"
+write_package "$workdir/Interfaces" "" ""
+find "$workdir/Interfaces/Cadova.xcframework" -name "*.swiftmodule" -type f -delete
+find "$workdir/Interfaces/Cadova.xcframework" -name "*.swiftdoc" -type f -delete
+remaining=$(find "$workdir/Interfaces/Cadova.xcframework" -name "*.swiftinterface" | wc -l | tr -d ' ')
+[[ $remaining -gt 0 ]] || fail "removing the binary modules left no interfaces to compile"
+echo "    compiling against $remaining interfaces alone"
+cp "$workdir/model.swift" "$workdir/Interfaces/Sources/SmokeTest/main.swift"
+build_and_run "$workdir/Interfaces" debug "the interface-only test"
+
+# Cadova bundles ThreeMF. A client that also depends on ThreeMF must still link, which only
+# holds while the bundled copy's symbols stay private to the artifact.
+echo "==> Checking that a client can depend on a bundled dependency directly"
+write_package "$workdir/Coexist" \
+    '.package(url: "https://github.com/tomasf/ThreeMF.git", .upToNextMinor(from: "0.3.0"))' \
+    ', .product(name: "ThreeMF", package: "ThreeMF")'
+{
+    echo "import ThreeMF"
+    echo "_ = ThreeMFError.self"
+    cat "$workdir/model.swift"
+} > "$workdir/Coexist/Sources/SmokeTest/main.swift"
+build_and_run "$workdir/Coexist" debug "the coexistence test"
+
+echo "==> $xcframework verified"

--- a/Sources/Cadova/Abstract Layer/2D/Text/TextRendering.swift
+++ b/Sources/Cadova/Abstract Layer/2D/Text/TextRendering.swift
@@ -203,6 +203,9 @@ fileprivate extension Apus.Path {
             case .close:
                 // Close is implicit in BezierPath - just continue with current path
                 break
+
+            @unknown default:
+                preconditionFailure("Unsupported glyph path element: \(element)")
             }
         }
 

--- a/Sources/Cadova/Abstract Layer/Import/2D/GeometrySVGConsumer.swift
+++ b/Sources/Cadova/Abstract Layer/Import/2D/GeometrySVGConsumer.swift
@@ -192,6 +192,8 @@ internal final class ShapeExtractionRenderer: SVGRenderer {
         case .start: .left
         case .middle: .center
         case .end: .right
+        // SVG's initial value for text-anchor
+        @unknown default: .left
         }
 
         let position = transformPoint(x: text.x, y: text.y)

--- a/Sources/Cadova/Abstract Layer/Import/2D/PelagosEnumConversions.swift
+++ b/Sources/Cadova/Abstract Layer/Import/2D/PelagosEnumConversions.swift
@@ -8,6 +8,9 @@ internal extension FillRule {
             self = .nonZero
         case .evenodd:
             self = .evenOdd
+        @unknown default:
+            // SVG's initial value for fill-rule
+            self = .nonZero
         }
     }
 }
@@ -21,6 +24,9 @@ internal extension LineJoinStyle {
             self = .round
         case .bevel:
             self = .bevel
+        @unknown default:
+            // SVG's initial value for stroke-linejoin
+            self = .miter
         }
     }
 }
@@ -34,6 +40,9 @@ internal extension LineCapStyle {
             self = .round
         case .square:
             self = .square
+        @unknown default:
+            // SVG's initial value for stroke-linecap
+            self = .butt
         }
     }
 }

--- a/Sources/Cadova/Cadova.docc/GettingStarted.md
+++ b/Sources/Cadova/Cadova.docc/GettingStarted.md
@@ -46,6 +46,8 @@ let package = Package(
 )
 ```
 
+> Note: On macOS this resolves to a prebuilt XCFramework rather than building Cadova from source, which roughly halves the first build and cuts the CPU work it costs by about ten times. The binary is an optimized release build, so your models also run at release speed in a debug build, several times faster than a debug Cadova. Linux and Windows build from source. To build from source on macOS as well, set `CADOVA_BUILD_FROM_SOURCE=1` in the environment.
+
 ## 4. Use Cadova
 
 Edit `main.swift`:


### PR DESCRIPTION
On macOS, Cadova resolves to a prebuilt, optimized XCFramework instead of building from source. Consumers change nothing in their manifest. Linux and Windows build from source, as before, and Cadova's own checkout always builds from source so that its tests, its documentation and the artifact itself come from the working tree.

Measured on a boolean-heavy model, building a consumer package clean and running it once:

| | From source | From the binary |
| --- | --- | --- |
| Clean debug build, wall clock | 75 s | 35 s |
| Clean debug build, CPU time | 271 s | 27 s |
| Running the model from a debug build | 1.63 s | 0.27 s |

The CPU figure matters most on a laptop or a small CI runner. The download is about 10 MB.

## How it works

Swift cannot export a C or C++ target from a binary package, and Cadova depends on several: Manifold, oneTBB, Clipper2, pugixml, miniz, FreeType and HarfBuzz. None of them appear in Cadova's public API, so they only need to be present as object code. A static library provides exactly that, and only the four Swift modules Cadova's interface names are exported.

Bundling those modules would otherwise collide with a client's own copies. A package depending on both the binary Cadova and ThreeMF failed to link with 642 duplicate symbols. Each architecture's archive is therefore relinked into a single object with every symbol outside an exported module made private, about 17,700 per architecture. Manifold3D stays visible, because Cadova's own API is written in terms of it.

Two upstream problems needed working around. Library evolution rejects a switch over another module's enum without `@unknown default`, so the five conversions from Apus and Pelagos enums gained one each, falling back to the SVG initial value for that property. And Swift's module interface printer emits a redundant associated type witness for types conforming to a parameterized protocol, which makes the interface uncompilable; `Scripts/repair-module-interface.py` uses the compiler as the oracle to delete exactly those witnesses and then type-checks the result unconditionally.

## Verification

Three scripts, all run by the workflow on every push and pull request:

- `Scripts/verify-xcframework.sh` builds and runs a model against the artifact in both debug and release, exercising every bundled dependency, then repeats it with the binary modules deleted so the textual interfaces are compiled instead, then again in a package that also depends on ThreeMF directly.
- `Scripts/verify-manifest-selection.sh` copies the manifest into a directory shaped like a dependency checkout and asks SwiftPM which target it chose, since nothing about that decision shows up in an ordinary build.
- `Scripts/verify-published-release.sh` consumes a published release from its URL and checks the recorded checksum. A CI job runs it right after publishing.

A second CI job consumes the artifact on a different Swift version, and publishing waits on it.

## Releasing

The workflow is read-only on a push or a pull request. To publish, run it manually with a version. It uploads the artifact to a release and commits the resulting checksum into `Package.swift`, pushing that commit before the release creates the tag so a tag can never point at a missing download.

Until that happens, `binaryChecksum` is a placeholder of zeros and every path falls back to a source build, so merging this changes nothing for users until you choose to publish.

## Notes

- `CADOVA_BUILD_FROM_SOURCE=1` opts out on macOS. `CADOVA_USE_BINARY=1` and `CADOVA_LOCAL_XCFRAMEWORK=<relative path>` are there for working on the artifact itself.
- `binaryURL` points at `tomasf/Cadova` releases, which is where the publish job uploads when run from this repository.
- 814 tests pass from source. The three scripts above pass locally on Swift 6.3.3 and Xcode 26.6.
